### PR TITLE
Implement contour filtering by motion mask

### DIFF
--- a/src/wildcamtools/cli/watch.py
+++ b/src/wildcamtools/cli/watch.py
@@ -76,7 +76,7 @@ class WatcherManager:
     hwaccel: str
     segment_duration: int
     transition_metrics: WatcherTransitionMetrics
-
+    motion_mask: Path | None
     msg_queue: Queue
     stat: WatcherManagerStateEnum
     motion_process: Process | None = None
@@ -98,6 +98,7 @@ class WatcherManager:
         hwaccel: str,
         segment_duration: int,
         transition_metrics: WatcherTransitionMetrics,
+        motion_mask: Path | None = None,
     ) -> None:
         self.rtsp_stream = rtsp_stream
         self.segments_dir = segments_dir
@@ -113,6 +114,7 @@ class WatcherManager:
         self.hwaccel = hwaccel
         self.segment_duration = segment_duration
         self.transition_metrics = transition_metrics
+        self.motion_mask = motion_mask
 
         self.msg_queue = Queue()
         self.state = WatcherManagerStateEnum.WAITING
@@ -134,7 +136,9 @@ class WatcherManager:
                 fps=self.fps,
                 hwaccel=self.hwaccel,
                 transition_metrics=self.transition_metrics,
+                motion_mask=self.motion_mask,
             )
+
 
         # check and create segment process
         if self.segment_process and self.segment_process.poll() is not None:
@@ -254,9 +258,20 @@ def watch(
     red_amber_to_green_duration: Annotated[
         int, typer.Option(metavar="INT", envvar="WTC_RED_AMBER_2_GREEN_DURATION")
     ] = 5,  # frames
+    motion_mask: Annotated[Path | None, typer.Option(metavar="PATH", envvar="WTC_MOTION_MASK")] = None,
 ) -> None:
 
+    if motion_mask:
+        motion_mask = motion_mask.resolve()
+        if not motion_mask.exists():
+            raise typer.BadParameter(f"motion_mask file does not exist: {motion_mask}")
+        if not motion_mask.is_file():
+            raise typer.BadParameter(f"motion_mask path is not a file: {motion_mask}")
+        if not os.access(motion_mask, os.R_OK):
+            raise typer.BadParameter(f"motion_mask file is not readable: {motion_mask}")
+
     # TODO validate rtsp_stream is a rtsp url
+
 
     segments = segments.resolve()
     if not segments.is_dir() or not segments.exists():
@@ -289,6 +304,7 @@ def watch(
         hwaccel=hwaccel,
         segment_duration=segment_duration,
         transition_metrics=transition_metrics,
+        motion_mask=motion_mask,
     )
     watcher.run()
 

--- a/src/wildcamtools/lib/motion.py
+++ b/src/wildcamtools/lib/motion.py
@@ -17,10 +17,13 @@ class MotionHandler(FrameHandler):
         self,
         history: int,
         kernel_size: int = 3,
+        motion_mask: np.ndarray | None = None,
     ):
         self.history = history
         self.kernel_size = kernel_size
         self.kernel = np.ones((self.kernel_size, self.kernel_size), np.uint8)
+        self.motion_mask = motion_mask
+
 
     def handle(self, frame: Frame) -> Frame:
         frame_out = self.update_background(frame.raw)
@@ -37,8 +40,53 @@ class MotionHandler(FrameHandler):
             return cv2.countNonZero(frame) / (float(frame.shape[0]) * float(frame.shape[1]))
         else:
             contours, _ = cv2.findContours(frame, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-            # TODO filter contours remove those whose lowest point is in the masked areas
-            areas = (cv2.contourArea(cnt) for cnt in contours)
+
+            # Filter out contours whose lowest point (max Y coordinate) is within a masked area.
+            # If a contour has multiple points with the same maximum Y coordinate,
+            # we consider it masked if ANY of those points are in a masked area.
+            # This prevents motion in specifically excluded regions (like moving foliage at the top)
+            # from triggering a motion detection.
+            filtered_contours = []
+            for cnt in contours:
+                # Find the maximum Y coordinate among all points in the contour
+                # cnt shape is (N, 1, 2)
+                max_y = np.max(cnt[:, 0, 1])
+
+                # Find all points that have this maximum Y coordinate
+                lowest_points = cnt[cnt[:, 0, 1] == max_y]
+
+                # The contour is removed if ANY of its lowest points are in a masked area
+                is_masked = False
+                if self.motion_mask is not None:
+                    mh, mw = self.motion_mask.shape
+                    # Extract coordinates of points at the lowest Y level
+                    pts = [ (int(p[0, 0]), int(p[0, 1])) for p in lowest_points ]
+
+                    # Check the points themselves
+                    for x, y in pts:
+                        if 0 <= y < mh and 0 <= x < mw:
+                            if self.motion_mask[y, x] != 0:
+                                is_masked = True
+                                break
+
+                    # For CHAIN_APPROX_SIMPLE, a straight bottom edge is represented by only its endpoints.
+                    # We check the segment between the leftmost and rightmost points at max_y.
+                    if not is_masked and len(pts) >= 2:
+                        # Sort by X coordinate
+                        pts.sort()
+                        x_start, y_start = pts[0]
+                        x_end, y_end = pts[-1]
+                        # Scan along the horizontal segment at max_y
+                        for x_sample in range(x_start, x_end + 1):
+                            if 0 <= y_start < mh and 0 <= x_sample < mw:
+                                if self.motion_mask[y_start, x_sample] != 0:
+                                    is_masked = True
+                                    break
+
+                if not is_masked:
+                    filtered_contours.append(cnt)
+
+            areas = (cv2.contourArea(cnt) for cnt in filtered_contours)
             area_total = sum(areas)
             area_propotion = area_total / (float(frame.shape[0]) * float(frame.shape[1]))
             return area_propotion
@@ -59,8 +107,9 @@ class MogMotion(MotionHandler):
         threshold: int = 16,
         detect_shadows: bool = False,
         kernel_size: int = 3,
+        motion_mask: np.ndarray | None = None,
     ):
-        super().__init__(history=history, kernel_size=kernel_size)
+        super().__init__(history=history, kernel_size=kernel_size, motion_mask=motion_mask)
         self.threshold = threshold
         self.detect_shadows = detect_shadows
 
@@ -85,8 +134,9 @@ class AvgMotion(MotionHandler):
         history: int = 500,
         threshold: int = 16,
         kernel_size: int = 3,
+        motion_mask: np.ndarray | None = None,
     ):
-        super().__init__(history=history, kernel_size=kernel_size)
+        super().__init__(history=history, kernel_size=kernel_size, motion_mask=motion_mask)
         self.threshold = threshold
 
     def update_background(self, frame: MatLike) -> MatLike:

--- a/src/wildcamtools/lib/states.py
+++ b/src/wildcamtools/lib/states.py
@@ -3,8 +3,11 @@ from collections.abc import Generator
 from datetime import UTC, datetime
 from enum import StrEnum
 from multiprocessing import Process, Queue
+from pathlib import Path
 from typing import Self
 
+import cv2
+import numpy as np
 from pydantic import BaseModel
 
 from wildcamtools.lib import Frame, FrameHandler
@@ -149,6 +152,36 @@ class Watcher(FrameHandler):
         return self.state
 
 
+def _load_and_resize_mask(mask_path: Path, width: int, height: int, scale: float) -> np.ndarray | None:
+    if mask_path is None:
+        return None
+
+    mask = cv2.imread(str(mask_path), cv2.IMREAD_GRAYSCALE)
+    if mask is None:
+        logger.error(f"Failed to load motion mask from {mask_path}. "
+                     f"The file may be corrupted or in an unsupported image format.")
+        return None
+
+    # Target size is the scaled dimensions of the frame
+    target_width = int(width * scale)
+    target_height = int(height * scale)
+
+    # Aspect ratio check
+    mask_h, mask_w = mask.shape[:2]
+    stream_aspect = width / height
+    mask_aspect = mask_w / mask_h
+
+    if abs(stream_aspect - mask_aspect) > 0.05:
+        logger.warning(f"Motion mask aspect ratio ({mask_aspect:.2f}) differs significantly "
+                       f"from stream aspect ratio ({stream_aspect:.2f}). "
+                       f"The mask will be stretched to fit.")
+
+    # Resize using nearest neighbor to keep binary mask properties
+    mask = cv2.resize(mask, (target_width, target_height), interpolation=cv2.INTER_NEAREST)
+    return mask
+
+
+
 def enqueue_motion_windows(
     rtsp_stream: str,
     queue: Queue,
@@ -159,6 +192,7 @@ def enqueue_motion_windows(
     fps: float,
     hwaccel: str,
     transition_metrics: WatcherTransitionMetrics,
+    motion_mask: Path | None = None,
 ) -> None:
     def _find_motion_times(source: str, stats: VideoStats, watcher: Watcher) -> Generator[MotionWindow]:
         start_frame: int | None = None
@@ -199,16 +233,24 @@ def enqueue_motion_windows(
                     start_frame = None
                     start_time = None
 
+    stats = get_video_stats(rtsp_stream)
+    processed_mask = _load_and_resize_mask(
+        mask_path=motion_mask,
+        width=stats.x,
+        height=stats.y,
+        scale=scale,
+    )
+
     watcher = Watcher(
         motion=MogMotion(
             history=history,
             threshold=threshold,
             detect_shadows=False,
             kernel_size=kernel_size,
+            motion_mask=processed_mask,
         ),
         transition_metrics=transition_metrics,
     )
-    stats = get_video_stats(rtsp_stream)
     for motion in _find_motion_times(rtsp_stream, stats, watcher):
         queue.put(motion)
 
@@ -222,6 +264,7 @@ def create_motion_process(
     fps: float,
     hwaccel: str,
     transition_metrics: WatcherTransitionMetrics,
+    motion_mask: Path | None = None,
 ) -> Process:
     motion_process = Process(
         target=enqueue_motion_windows,
@@ -235,6 +278,7 @@ def create_motion_process(
             "fps": fps,
             "hwaccel": hwaccel,
             "transition_metrics": transition_metrics,
+            "motion_mask": motion_mask,
         },
         daemon=True,
         name="wildcamtools-motion",

--- a/tests/lib/test_motion_mask.py
+++ b/tests/lib/test_motion_mask.py
@@ -1,0 +1,59 @@
+
+import numpy as np
+import pytest
+
+from wildcamtools.lib.motion import MogMotion
+
+
+def test_motion_mask_filtering():
+    # Initialize motion handler with mask in constructor
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[50:, :] = 255  # Mask bottom half
+    motion = MogMotion(history=1, motion_mask=mask)
+
+    # Create a binary motion frame with two blobs
+    # Blob 1: Top half (should be kept)
+    # Blob 2: Bottom half (should be removed)
+    frame_raw = np.zeros((100, 100), dtype=np.uint8)
+    frame_raw[10:20, 10:20] = 255 # Top blob
+    frame_raw[60:70, 60:70] = 255 # Bottom blob
+
+    prop = motion.get_motion_proportion(frame_raw)
+
+    # We use pytest.approx because cv2.contourArea can be slightly
+    # different from the exact pixel count of a rectangle.
+    assert prop == pytest.approx(0.0081, abs=1e-4)
+
+def test_motion_multiple_lowest_points_masked():
+    # Initialize motion handler with mask in constructor
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[70, 40:60] = 255  # Mask a horizontal strip at Y=70
+    motion = MogMotion(history=1, motion_mask=mask)
+
+    frame_raw = np.zeros((100, 100), dtype=np.uint8)
+    # Use a slightly larger block to ensure a proper contour is found
+    frame_raw[60:71, 30:71] = 255
+
+    prop = motion.get_motion_proportion(frame_raw)
+
+    assert prop == 0.0
+
+def test_motion_mask_intersects_bottom_edge():
+    # Initialize motion handler
+    motion = MogMotion(history=1)
+
+    # Create a mask that only covers the MIDDLE of the bottom edge
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[70, 45:55] = 255 # Small mask in the center of the bottom edge
+    motion.motion_mask = mask
+
+    # Create a blob whose bottom edge is at Y=70 from X=30 to X=70
+    # The endpoints (30, 70) and (70, 70) are NOT masked
+    # But the middle (45-55, 70) IS masked
+    frame_raw = np.zeros((100, 100), dtype=np.uint8)
+    frame_raw[60:71, 30:71] = 255
+
+    prop = motion.get_motion_proportion(frame_raw)
+
+    # The contour should be removed because the mask intersects the bottom edge
+    assert prop == 0.0


### PR DESCRIPTION
Closes #2

## Summary
Implemented the TODO in `src/wildcamtools/lib/motion.py` to filter out contours whose lowest point falls within a masked area.

### Changes
- **Motion Filtering**: Updated `get_motion_proportion` to identify the lowest points (max Y) of contours and remove them if any of those points (or the horizontal segment between them) are in a masked area.
- **CLI Integration**: Added `--motion-mask` option to the `watch` command in `src/wildcamtools/cli/watch.py`, allowing a mask image file to be specified.
- **Propagation**: Updated `WatcherManager` and `create_motion_process` to propagate the mask path.
- **Preprocessing**: Added `_load_and_resize_mask` in `src/wildcamtools/lib/states.py` to load masks as greyscale, resize them to match the scaled frame dimensions using `INTER_NEAREST`, and log warnings for aspect ratio mismatches.
- **Validation**: Implemented fail-fast validation in the CLI to ensure the mask file exists and is readable.
- **Testing**: Added `tests/lib/test_motion_mask.py` with comprehensive test cases, including:
    - Standard masking of blobs.
    - Handling of contours with multiple points at the maximum Y level.
    - Filtering when the mask intersects the middle of a straight bottom edge (using `CHAIN_APPROX_SIMPLE`).

This prevents motion in specific excluded regions (e.g., moving foliage) from affecting motion detection calculations.