### PR TITLE
refactor: replace f-strings with %-style formatting in logging

### DIFF
--- a/src/wildcamtools/cli/watch.py
+++ b/src/wildcamtools/cli/watch.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 def find_segments_for_timespan(start_time: datetime, end_time: datetime, segments_dir: Path) -> tuple[Path, ...] | None:
-    logger.info(f"Finding segments from {start_time} to {end_time}")
+    logger.info("Finding segments from %s to %s", start_time, end_time)
     # given a directory
 
     # build a list of files in segment directory
@@ -43,12 +43,12 @@ def find_segments_for_timespan(start_time: datetime, end_time: datetime, segment
     ftime_string = "seg_%Y_%m_%d__%H_%M_%S.mp4"
     start_time_path = segments_dir / start_time.strftime(ftime_string)
     end_time_path = segments_dir / end_time.strftime(ftime_string)
-    logger.info(f"Finding segments from {start_time_path} to {end_time_path}")
+    logger.info("Finding segments from %s to %s", start_time_path, end_time_path)
 
     # work out where in the list the start and end filenames would be inserted
     start_position = bisect.bisect_left(segments_files, start_time_path)
     end_position = bisect.bisect_right(segments_files, end_time_path)
-    logger.info(f"Segment positions from {start_position} to {end_position}")
+    logger.info("Segment positions from %s to %s", start_position, end_position)
 
     if end_position == len(segments_files):
         # if we would cover the last file, beware
@@ -174,7 +174,7 @@ class WatcherManager:
             self.check_and_start_processes()
             sleep(self.segment_duration)
         output_file = self.output_dir / start_time.strftime("out_%Y_%m_%d__%H_%M_%S.mp4")
-        logger.info(f"Joining {len(to_merge)} segments into {output_file}")
+        logger.info("Joining %s segments into %s", len(to_merge), output_file)
         concat_ffmpeg(to_merge, output_file)
 
         # also output a JSON summary
@@ -191,7 +191,7 @@ class WatcherManager:
             # identify the oldest ones
             files_to_remove = files[keep:]
             for file_to_remove in files_to_remove:
-                logger.debug(f"removing {self.segments_dir / file_to_remove}")
+                logger.debug("removing %s", self.segments_dir / file_to_remove)
                 os.unlink(self.segments_dir / file_to_remove)
 
     def run(self) -> None:

--- a/src/wildcamtools/lib/frames.py
+++ b/src/wildcamtools/lib/frames.py
@@ -109,7 +109,7 @@ class FrameImageWriter(FrameHandler):
         if frame.filter_keep:
             filename = self.output_dir / f"frame_{frame.frame_no:05d}.jpg"
             cv2.imwrite(str(filename), frame.raw)
-            logger.debug(f"Writing {frame.frame_no} -> {filename}")
+            logger.debug("Writing %s -> %s", frame.frame_no, filename)
         return frame
 
 
@@ -159,7 +159,7 @@ class Rescaler(FrameHandler):
             while self.now >= self.target_frametime:
                 self.now -= self.target_frametime
 
-            logger.debug(f"Rescaled {frame.frame_no}")
+            logger.debug("Rescaled %s", frame.frame_no)
             return Frame(
                 raw=frame_rescaled,
                 frame_no=frame.frame_no,
@@ -202,7 +202,7 @@ class FilterSSIM(FrameHandler):
 
         # this calculation is pretty slow
         similarity = float(structural_similarity(frame_previous_resized, frame_resized, data_range=255, channel_axis=2))
-        logger.debug(f"SSIM ({frame.frame_no}) = {similarity:04f}")
+        logger.debug("SSIM (%s) = %04f", frame.frame_no, similarity)
 
         if similarity > self.similarity_minimum:
             # frame is too similar to the previous interesting frame, skip it
@@ -317,7 +317,12 @@ class CropPanHandler(FrameHandler):
         crop = frame.raw[self.window.y1 : self.window.y2, self.window.x1 : self.window.x2]
         # output the cropped version
         logger.debug(
-            f"Crop {frame.frame_no} to ({self.window.x1},{self.window.y1})-({self.window.x2},{self.window.y2})"
+            "Crop %s to (%s,%s)-(%s,%s)",
+            frame.frame_no,
+            self.window.x1,
+            self.window.y1,
+            self.window.x2,
+            self.window.y2,
         )
         return Frame(
             raw=crop,

--- a/src/wildcamtools/lib/label.py
+++ b/src/wildcamtools/lib/label.py
@@ -66,7 +66,7 @@ def save_and_next(output_path: Path, current_vid_name: str, label: str, videos: 
         save_label(output_path, current_vid_name, label)
         # Update cache
         st.session_state.labels[current_vid_name] = label
-        logger.info(f"Labeled {current_vid_name} as {label}")
+        logger.info("Labeled %s as %s", current_vid_name, label)
 
         # Move to next video
         if st.session_state.vid_idx < len(videos) - 1:
@@ -78,7 +78,7 @@ def save_and_next(output_path: Path, current_vid_name: str, label: str, videos: 
             logger.info("Finished labeling all videos")
     else:
         st.error("Please enter a label before saving.")
-        logger.warning(f"Attempted to save label for {current_vid_name} without providing a label")
+        logger.warning("Attempted to save label for %s without providing a label", current_vid_name)
 
 
 def main() -> None:
@@ -92,7 +92,7 @@ def main() -> None:
 
     if not vid_dir or not os.path.isdir(vid_dir):
         st.warning("Please provide a valid video directory.")
-        logger.warning(f"Invalid video directory provided: {vid_dir}")
+        logger.warning("Invalid video directory provided: %s", vid_dir)
         return
 
     # Get list of videos
@@ -104,7 +104,7 @@ def main() -> None:
 
     if not videos:
         st.info("No videos found in the specified directory.")
-        logger.info(f"No videos found in directory: {vid_dir}")
+        logger.info("No videos found in directory: %s", vid_dir)
         return
 
     # State for current video index

--- a/src/wildcamtools/lib/states.py
+++ b/src/wildcamtools/lib/states.py
@@ -110,8 +110,8 @@ class Watcher(FrameHandler):
             self.transition_window_metrics[next_state].update(frame.motion_proportion)
 
     def _get_next_state(self, frame: Frame) -> WatcherStateEnum:  # noqa: C901
-        logger.debug(f"Frame no: {frame.frame_no}")
-        logger.debug(f"Motion proportion: {frame.motion_proportion}")
+        logger.debug("Frame no: %s", frame.frame_no)
+        logger.debug("Motion proportion: %s", frame.motion_proportion)
         match self.state:
             case WatcherStateEnum.PREPARING:
                 if frame.frame_no >= self.transition_metrics.preparing_duration:

--- a/src/wildcamtools/lib/vidio.py
+++ b/src/wildcamtools/lib/vidio.py
@@ -158,9 +158,9 @@ class FrameSourceFFMPEG(FrameSource):
     def __enter__(self) -> Self:
         self._temporary_dir = Path(tempfile.mkdtemp(prefix="wildcamtools_"))
         self._named_pipe = self._temporary_dir / "pipe.mp4"
-        logger.debug(f"Creating pipe {self._named_pipe}")
+        logger.debug("Creating pipe %s", self._named_pipe)
         os.mkfifo(self._named_pipe)
-        logger.debug(f"Created pipe {self._named_pipe}")
+        logger.debug("Created pipe %s", self._named_pipe)
 
         return self
 
@@ -190,12 +190,12 @@ class FrameSourceFFMPEG(FrameSource):
             raise StopIteration
 
         if not self._named_pipe_reader:
-            logger.debug(f"Opening pipe {self._named_pipe}")
+            logger.debug("Opening pipe %s", self._named_pipe)
             # have to open the pipe _after_ ffmpeg has started writing into the pipe
             # otherwise it hangs
             if self._named_pipe:
                 self._named_pipe_reader = open(self._named_pipe, "rb")  # noqa: SIM115
-            logger.debug(f"Opened pipe {self._named_pipe}")
+            logger.debug("Opened pipe %s", self._named_pipe)
 
         in_bytes = (
             self._named_pipe_reader.read(self.width * self.height * 3)


### PR DESCRIPTION
## Summary
Replaces all f-string formatting in logging statements with %-style formatting throughout the codebase.

## Changes
- 19 logging statements updated across 5 files
- Follows Python logging best practices (lazy evaluation with % formatting)
- All checks pass (ruff format, ruff check, mypy)

## Files Modified
- `src/wildcamtools/cli/watch.py` (5 changes)
- `src/wildcamtools/lib/frames.py` (4 changes)
- `src/wildcamtools/lib/label.py` (4 changes)
- `src/wildcamtools/lib/states.py` (2 changes)
- `src/wildcamtools/lib/vidio.py` (4 changes)