### PR TITLE
Implement RTSPBroadcaster helper with PyAV

### DIFF
--- a/src/wildcamtools/lib/rtsp.py
+++ b/src/wildcamtools/lib/rtsp.py
@@ -1,12 +1,15 @@
 import logging
 import socket
+import threading
 from pathlib import Path
-from typing import override
+from typing import Self, override
 
+import av
 import ffmpeg
 import ffmpeg.codecs.encoders
 
 from wildcamtools.lib.background_process import BackgroundProcess
+from wildcamtools.lib.errors.core import translate_av_error
 
 logger = logging.getLogger(__name__)
 
@@ -58,3 +61,76 @@ class BackgroundFFMPEGBroadcast(BackgroundProcess):
         )
         logger.debug(ffmpeg_cmd.compile_line())
         self.process = ffmpeg_cmd.run_async()
+
+
+class RTSPBroadcaster:
+    def __init__(
+        self,
+        source: str | Path,
+        rtsp_url: str,
+        loop: bool = True,
+    ):
+        self.source = Path(source).resolve()
+        self.rtsp_url = rtsp_url
+        self.loop = loop
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._broadcast_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def _broadcast_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._broadcast_once()
+                if not self.loop:
+                    break
+            except Exception:
+                if self._stop_event.is_set():
+                    break
+                logger.exception("Broadcast error")
+                if not self.loop:
+                    raise
+
+    def _broadcast_once(self) -> None:
+        try:
+            with av.open(str(self.source), mode="r") as input_container:
+                input_stream = input_container.streams.video[0]
+
+                with av.open(
+                    self.rtsp_url,
+                    mode="w",
+                    format="rtsp",
+                    options={"rtsp_transport": "tcp"},
+                ) as output_container:
+                    output_stream = output_container.add_stream("libx264", rate=input_stream.average_rate)
+                    output_stream.width = input_stream.width
+                    output_stream.height = input_stream.height
+                    output_stream.pix_fmt = "yuv420p"
+
+                    for packet in input_container.demux(input_stream):
+                        if self._stop_event.is_set():
+                            break
+                        for frame in packet.decode():
+                            output_container.mux(output_stream.encode(frame))
+
+                    output_container.mux(output_stream.encode(None))
+        except Exception as e:
+            raise translate_av_error(e, str(self.source), "RTSP broadcast") from e
+
+    def __enter__(self) -> Self:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: object | None) -> None:
+        self.stop()
+
+    # TODO: support frame iterator source in addition to file path


### PR DESCRIPTION
## Summary
Replace BackgroundFFMPEGBroadcast with RTSPBroadcaster using PyAV for direct RTSP broadcasting.

## Changes
- Add `RTSPBroadcaster` class in `rtsp.py`
- Background thread for continuous broadcasting
- Loop support for file sources
- Context manager protocol (`__enter__`, `__exit__`)
- Methods: `start()`, `stop()`
- Integration with error handling framework
- Python logging integration
- No subprocess

## Dependencies
- Depends on #33 (Add PyAV dependency)
- Depends on error handling framework

## Testing
- Passes ruff check and mypy
- Integration tests with MediaMTX in later phase

## TODO
- Frame iterator source support