### PR TITLE
Migrate concat function to use PyAV

### DIFF
--- a/src/wildcamtools/cli/watch.py
+++ b/src/wildcamtools/cli/watch.py
@@ -14,7 +14,7 @@ from typing import Annotated
 import typer
 from typer_config import use_yaml_config
 
-from wildcamtools.lib.concat import concat_ffmpeg
+from wildcamtools.lib.concat import concat_videos
 from wildcamtools.lib.errors import (
     CannotCombineOpenWindowError,
     MotionMaskNotExistsError,
@@ -175,7 +175,7 @@ class WatcherManager:
             sleep(self.segment_duration)
         output_file = self.output_dir / start_time.strftime("out_%Y_%m_%d__%H_%M_%S.mp4")
         logger.info(f"Joining {len(to_merge)} segments into {output_file}")
-        concat_ffmpeg(to_merge, output_file)
+        concat_videos(to_merge, output_file)
 
         # also output a JSON summary
         with open(self.output_dir / start_time.strftime("out_%Y_%m_%d__%H_%M_%S.json"), "w") as json_out:

--- a/src/wildcamtools/lib/concat.py
+++ b/src/wildcamtools/lib/concat.py
@@ -1,36 +1,56 @@
 import logging
 import tempfile
 from collections.abc import Iterable
+from contextlib import suppress
 from pathlib import Path
 
-import ffmpeg
+import av
+
+from wildcamtools.lib.errors.core import translate_av_error
 
 logger = logging.getLogger(__name__)
 
 
-def concat_ffmpeg(inputs: Iterable[Path], output: Path) -> None:
-    # https://stackoverflow.com/questions/7333232/how-to-concatenate-two-mp4-files-using-ffmpeg
-    # see https://ffmpeg.org/ffmpeg-formats.html#concat-1
+def concat_videos(inputs: Iterable[Path], output: Path) -> None:
+    """Concatenate video files using PyAV concat demuxer.
 
-    with tempfile.NamedTemporaryFile("w+t", suffix=".txt") as list_file:
-        list_file.write("ffconcat version 1.0\n")
-        for filename in inputs:
-            # TODO escape special characters, but WTF are you doing with special character in filenames?!?
-            list_file.write(f"file '{filename.resolve()}'\n")
-        list_file.flush()
-        ff = (
-            ffmpeg.input(
-                list_file.name,
-                f="concat",
-                extra_options={"safe": "0"},  # allow absolute paths
-            )
-            .output(
-                filename=output.resolve(),
-                c="copy",
-            )
-            .global_args(hide_banner=True, loglevel="error")
-            .overwrite_output()
-        )
-        logger.debug(ff.compile_line())
-        ff.run()
-        # TODO use ffmpeg to create a temporary filename, then atomically rename into final
+    Uses FFmpeg concat demuxer via PyAV with stream copy (no re-encoding).
+
+    Args:
+        inputs: Iterable of input video file paths
+        output: Output video file path
+
+    Raises:
+        ContainerError: If concat operation fails
+    """
+    inputs_list = list(inputs)
+    logger.debug("Concatenating %d videos to %s", len(inputs_list), output)
+
+    list_file_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w+t", suffix=".txt", delete=False) as list_file:
+            list_file.write("ffconcat version 1.0\n")
+            for filename in inputs_list:
+                # TODO escape special characters in filenames
+                list_file.write(f"file '{filename.resolve()}'\n")
+            list_file_path = list_file.name
+
+        with (
+            av.open(
+                list_file_path,
+                format="concat",
+                options={"safe": "0"},
+            ) as container,
+            av.open(output, "w") as output_container,
+        ):
+            for packet in container.demux():
+                output_container.mux(packet)
+
+        logger.debug("Successfully concatenated %d videos", len(inputs_list))
+
+    except Exception as e:
+        raise translate_av_error(e, str(output), "concat") from e
+    finally:
+        if list_file_path is not None:
+            with suppress(Exception):
+                Path(list_file_path).unlink()

--- a/src/wildcamtools/lib/errors/core.py
+++ b/src/wildcamtools/lib/errors/core.py
@@ -143,3 +143,106 @@ class InertiaValueError(ValueError):
 class ExpansionValueError(ValueError):
     def __init__(self) -> None:
         super().__init__("Expansion is not valid")
+
+
+class PyAVError(Exception):
+    """Base exception for PyAV/FFmpeg-related errors."""
+
+
+class VideoReadError(PyAVError):
+    """Exception raised when reading video frames fails."""
+
+    def __init__(self, filename: str, operation: str, details: str | None = None) -> None:
+        message = f"Failed to read from '{filename}' during {operation}"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class VideoWriteError(PyAVError):
+    """Exception raised when writing video frames fails."""
+
+    def __init__(self, filename: str, operation: str, details: str | None = None) -> None:
+        message = f"Failed to write to '{filename}' during {operation}"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class ContainerError(PyAVError):
+    """Exception raised when container operations fail."""
+
+    def __init__(self, filename: str, operation: str, details: str | None = None) -> None:
+        message = f"Container operation failed for '{filename}' during {operation}"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class CodecError(PyAVError):
+    """Exception raised when codec operations fail."""
+
+    def __init__(self, filename: str, codec_name: str, details: str | None = None) -> None:
+        message = f"Codec '{codec_name}' failed for '{filename}'"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class StreamNotFoundError(PyAVError):
+    """Exception raised when a stream is not found in a container."""
+
+    def __init__(self, filename: str, stream_type: str = "video") -> None:
+        super().__init__(f"No {stream_type} stream found in '{filename}'")
+
+
+def translate_av_error(error: Exception, filename: str = "", operation: str = "operation") -> PyAVError:  # noqa: C901
+    """Translate a PyAV/FFmpeg exception to a domain-specific exception.
+
+    Maps av.error.FFmpegError and related exceptions to appropriate
+    domain-specific PyAVError subclasses based on error context.
+
+    Args:
+        error: The original exception from PyAV/FFmpeg
+        filename: The file being operated on
+        operation: Description of the operation being performed
+
+    Returns:
+        A PyAVError subclass with contextual information
+    """
+    import av.error
+
+    error_name = type(error).__name__
+    error_str = str(error)
+
+    if isinstance(error, av.error.FFmpegError):
+        if "No such file" in error_str or "Operation not permitted" in error_str:
+            return ContainerError(filename, operation, error_str)
+
+        if "Invalid data format" in error_str or "Invalid argument" in error_str:
+            return ContainerError(filename, operation, error_str)
+
+        if "Stream not found" in error_str or "Stream does not exist" in error_str:
+            return StreamNotFoundError(filename, "video")
+
+        if "Decoder not found" in error_str or "Encoder not found" in error_str:
+            return CodecError(filename, "unknown", error_str)
+
+        if "Error while decoding" in error_str:
+            return VideoReadError(filename, operation, error_str)
+
+        if "Error while encoding" in error_str:
+            return VideoWriteError(filename, operation, error_str)
+
+        return ContainerError(filename, operation, f"{error_name}: {error_str}")
+
+    if isinstance(error, ValueError):
+        return CodecError(filename, "unknown", f"{error_str}")
+
+    if isinstance(error, (av.error.EOFError, EOFError)):
+        return VideoReadError(filename, operation, "End of file reached")
+
+    if isinstance(error, (av.error.TimeoutError, TimeoutError)):
+        return VideoReadError(filename, operation, "Operation timed out")
+
+    return PyAVError(f"{error_name}: {error_str} (file: {filename}, operation: {operation})")


### PR DESCRIPTION
## Summary
Replace concat_ffmpeg with PyAV-based concat_videos function.

## Changes
- Update `concat_videos()` in `concat.py` to use PyAV concat demuxer
- Stream copy (no re-encoding) via `output_container.mux(packet)`
- Integration with error handling framework
- Python logging integration
- Temp file cleanup in finally block
- No subprocess

## Dependencies
- Depends on #33 (Add PyAV dependency)
- Depends on error handling framework

## Testing
- Passes ruff check and mypy
- Integration tests in later phase

## TODO
- Atomic write (temp file + rename) for safety
- Escape special characters in filenames