### PR TITLE
Migrate calling code to use new PyAV helpers

### DIFF
--- a/samples/create.py
+++ b/samples/create.py
@@ -2,7 +2,6 @@ import tempfile
 from math import pi, sqrt
 from pathlib import Path
 
-import ffmpeg
 from PIL import Image, ImageDraw
 
 
@@ -53,22 +52,30 @@ def create_circle_frames(
 
 
 def create_video_from_frames(path_wildcard: Path, output: Path | str, fps: int = 30) -> None:
-    ffmpeg.input(
-        path_wildcard,
-        demuxer_options=ffmpeg.formats.demuxers.image2(
-            pattern_type="glob",
-            framerate=str(fps),
-        ),
-    ).output(
-        codec="libx264",
-        encoder_options=ffmpeg.codecs.encoders.libx264(),
-        filename=output,
-    ).global_args(
-        hide_banner=True,
-        loglevel="error",
-    ).overwrite_output().run(
-        quiet=True,
-    )
+    import av
+    import numpy as np
+
+    output_path = Path(output)
+    container = av.open(str(output_path), mode="w")
+    stream = container.add_stream("libx264", rate=fps)
+    stream.width = 1920
+    stream.height = 1080
+    stream.pix_fmt = "yuv420p"
+    stream.options = {"crf": "23", "preset": "medium"}
+
+    frame_files = sorted(path_wildcard.parent.glob(path_wildcard.name.replace("*", "*")))
+    for frame_file in frame_files:
+        img = Image.open(frame_file).convert("RGB")
+        frame_array = np.array(img)
+        av_frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+        av_frame.pts = stream.frames
+        for packet in stream.encode(av_frame):
+            container.mux(packet)
+
+    for packet in stream.encode(None):
+        container.mux(packet)
+
+    container.close()
 
 
 if __name__ == "__main__":

--- a/src/wildcamtools/cli/frames.py
+++ b/src/wildcamtools/cli/frames.py
@@ -10,7 +10,7 @@ from wildcamtools.lib.frames import CropPanHandler, FilterSSIM, FrameImageWriter
 from wildcamtools.lib.motion import FlowMotion
 from wildcamtools.lib.stats import get_video_stats
 from wildcamtools.lib.timing import Timer
-from wildcamtools.lib.vidio import FrameSourceFFMPEG
+from wildcamtools.lib.vidio import VideoReader
 
 app = typer.Typer()
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ def ssim(
 
     timer = Timer()
 
-    with FrameSourceFFMPEG(input_) as video_input:
+    with VideoReader(input_) as video_input:
         frame: Frame
         for frame in video_input:
             with timer:
@@ -101,7 +101,7 @@ def flow(
     )
     handlers.append(FrameImageWriter(output))
 
-    with FrameSourceFFMPEG(input_) as video_input:
+    with VideoReader(input_) as video_input:
         for frame in video_input:
             with timer:
                 for handler in handlers:

--- a/src/wildcamtools/cli/motion_mog2.py
+++ b/src/wildcamtools/cli/motion_mog2.py
@@ -8,7 +8,7 @@ from wildcamtools.lib.frames import MotionFlowHighlighter
 from wildcamtools.lib.motion import AvgMotion, FlowMotion, MogMotion, MotionHandler
 from wildcamtools.lib.stats import get_video_stats
 from wildcamtools.lib.timing import Timer
-from wildcamtools.lib.vidio import FrameSourceFFMPEG, FrameWriterFFMPEG
+from wildcamtools.lib.vidio import VideoReader, VideoWriter
 
 app = typer.Typer()
 
@@ -23,8 +23,8 @@ def _shared(
     timer = Timer()
 
     with (
-        FrameWriterFFMPEG(output, fps=fps) as video_writer,
-        FrameSourceFFMPEG(input_) as video_input,
+        VideoWriter(output, fps=fps) as video_writer,
+        VideoReader(input_) as video_input,
     ):
         frame_out = None
         for frame in video_input:
@@ -78,7 +78,7 @@ def flow_highlighter(
     handler = MotionFlowHighlighter(alpha=alpha, max_magnitude=magnitude)
     timer = Timer()
 
-    with FrameWriterFFMPEG(output, fps=stats.fps) as video_writer, FrameSourceFFMPEG(input_) as video_input:
+    with VideoWriter(output, fps=stats.fps) as video_writer, VideoReader(input_) as video_input:
         for frame in video_input:
             with timer:
                 frame = handler.handle(frame)

--- a/src/wildcamtools/cli/perftest.py
+++ b/src/wildcamtools/cli/perftest.py
@@ -7,13 +7,13 @@ from wildcamtools.lib.frames import Rescaler
 from wildcamtools.lib.motion import MogMotion
 from wildcamtools.lib.stats import get_video_stats
 from wildcamtools.lib.timing import Timer
-from wildcamtools.lib.vidio import FrameSourceFFMPEG, FrameWriterFFMPEG
+from wildcamtools.lib.vidio import VideoReader, VideoWriter
 
 app = typer.Typer()
 
 
 def convert(input_: str, output: str, fps: float, timer: Timer, handler: FrameHandler) -> None:
-    with FrameWriterFFMPEG(output, fps=fps) as video_writer, FrameSourceFFMPEG(input_) as video_input:
+    with VideoWriter(output, fps=fps) as video_writer, VideoReader(input_) as video_input:
         for frame in video_input:
             with timer:
                 frame_rescaled = handler.handle(frame)

--- a/src/wildcamtools/cli/rescale.py
+++ b/src/wildcamtools/cli/rescale.py
@@ -7,7 +7,7 @@ from wildcamtools.lib import Frame
 from wildcamtools.lib.frames import Rescaler
 from wildcamtools.lib.stats import get_video_stats
 from wildcamtools.lib.timing import Timer
-from wildcamtools.lib.vidio import FrameSourceFFMPEG, FrameWriterFFMPEG
+from wildcamtools.lib.vidio import VideoReader, VideoWriter
 
 app = typer.Typer()
 
@@ -25,7 +25,7 @@ def rescale(
     handler = Rescaler(stats=stats, x=x, y=y, fps=fps)
     timer = Timer()
 
-    with FrameWriterFFMPEG(output, fps=handler.fps) as video_writer, FrameSourceFFMPEG(input_) as video_input:
+    with VideoWriter(output, fps=handler.fps) as video_writer, VideoReader(input_) as video_input:
         frame: Frame
         for frame in video_input:
             with timer:

--- a/src/wildcamtools/cli/rtsp.py
+++ b/src/wildcamtools/cli/rtsp.py
@@ -3,14 +3,14 @@ from time import sleep
 
 import typer
 
-from wildcamtools.lib.rtsp import BackgroundFFMPEGBroadcast, BackgroundMediaMTX
+from wildcamtools.lib.rtsp import BackgroundMediaMTX, RTSPBroadcaster
 
 app = typer.Typer()
 
 
 @app.command()
 def serve(path: Path) -> None:
-    with BackgroundMediaMTX(), BackgroundFFMPEGBroadcast(path):
+    with BackgroundMediaMTX(), RTSPBroadcaster(path, "rtsp://localhost:8554/stream"):
         typer.secho("RTSP stream ready at rtsp://localhost:8554/stream")
         try:
             while True:

--- a/src/wildcamtools/cli/watch.py
+++ b/src/wildcamtools/cli/watch.py
@@ -14,7 +14,7 @@ from typing import Annotated
 import typer
 from typer_config import use_yaml_config
 
-from wildcamtools.lib.concat import concat_ffmpeg
+from wildcamtools.lib.concat import concat_videos
 from wildcamtools.lib.errors import (
     CannotCombineOpenWindowError,
     MotionMaskNotExistsError,
@@ -175,7 +175,7 @@ class WatcherManager:
             sleep(self.segment_duration)
         output_file = self.output_dir / start_time.strftime("out_%Y_%m_%d__%H_%M_%S.mp4")
         logger.info(f"Joining {len(to_merge)} segments into {output_file}")
-        concat_ffmpeg(to_merge, output_file)
+        concat_videos(to_merge, output_file)
 
         # also output a JSON summary
         with open(self.output_dir / start_time.strftime("out_%Y_%m_%d__%H_%M_%S.json"), "w") as json_out:

--- a/src/wildcamtools/lib/concat.py
+++ b/src/wildcamtools/lib/concat.py
@@ -1,36 +1,56 @@
 import logging
 import tempfile
 from collections.abc import Iterable
+from contextlib import suppress
 from pathlib import Path
 
-import ffmpeg
+import av
+
+from wildcamtools.lib.errors.core import translate_av_error
 
 logger = logging.getLogger(__name__)
 
 
-def concat_ffmpeg(inputs: Iterable[Path], output: Path) -> None:
-    # https://stackoverflow.com/questions/7333232/how-to-concatenate-two-mp4-files-using-ffmpeg
-    # see https://ffmpeg.org/ffmpeg-formats.html#concat-1
+def concat_videos(inputs: Iterable[Path], output: Path) -> None:
+    """Concatenate video files using PyAV concat demuxer.
 
-    with tempfile.NamedTemporaryFile("w+t", suffix=".txt") as list_file:
-        list_file.write("ffconcat version 1.0\n")
-        for filename in inputs:
-            # TODO escape special characters, but WTF are you doing with special character in filenames?!?
-            list_file.write(f"file '{filename.resolve()}'\n")
-        list_file.flush()
-        ff = (
-            ffmpeg.input(
-                list_file.name,
-                f="concat",
-                extra_options={"safe": "0"},  # allow absolute paths
-            )
-            .output(
-                filename=output.resolve(),
-                c="copy",
-            )
-            .global_args(hide_banner=True, loglevel="error")
-            .overwrite_output()
-        )
-        logger.debug(ff.compile_line())
-        ff.run()
-        # TODO use ffmpeg to create a temporary filename, then atomically rename into final
+    Uses FFmpeg concat demuxer via PyAV with stream copy (no re-encoding).
+
+    Args:
+        inputs: Iterable of input video file paths
+        output: Output video file path
+
+    Raises:
+        ContainerError: If concat operation fails
+    """
+    inputs_list = list(inputs)
+    logger.debug("Concatenating %d videos to %s", len(inputs_list), output)
+
+    list_file_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w+t", suffix=".txt", delete=False) as list_file:
+            list_file.write("ffconcat version 1.0\n")
+            for filename in inputs_list:
+                # TODO escape special characters in filenames
+                list_file.write(f"file '{filename.resolve()}'\n")
+            list_file_path = list_file.name
+
+        with (
+            av.open(
+                list_file_path,
+                format="concat",
+                options={"safe": "0"},
+            ) as container,
+            av.open(output, "w") as output_container,
+        ):
+            for packet in container.demux():
+                output_container.mux(packet)
+
+        logger.debug("Successfully concatenated %d videos", len(inputs_list))
+
+    except Exception as e:
+        raise translate_av_error(e, str(output), "concat") from e
+    finally:
+        if list_file_path is not None:
+            with suppress(Exception):
+                Path(list_file_path).unlink()

--- a/src/wildcamtools/lib/errors/__init__.py
+++ b/src/wildcamtools/lib/errors/__init__.py
@@ -24,6 +24,8 @@ from wildcamtools.lib.errors.core import (
     VideoNotInContextError,
     VideoProbeError,
     VideoSizeNotSetError,
+    VideoWriteError,
+    translate_av_error,
 )
 
 __all__ = [
@@ -50,4 +52,6 @@ __all__ = [
     "VideoNotInContextError",
     "VideoProbeError",
     "VideoSizeNotSetError",
+    "VideoWriteError",
+    "translate_av_error",
 ]

--- a/src/wildcamtools/lib/errors/core.py
+++ b/src/wildcamtools/lib/errors/core.py
@@ -143,3 +143,106 @@ class InertiaValueError(ValueError):
 class ExpansionValueError(ValueError):
     def __init__(self) -> None:
         super().__init__("Expansion is not valid")
+
+
+class PyAVError(Exception):
+    """Base exception for PyAV/FFmpeg-related errors."""
+
+
+class VideoReadError(PyAVError):
+    """Exception raised when reading video frames fails."""
+
+    def __init__(self, filename: str, operation: str, details: str | None = None) -> None:
+        message = f"Failed to read from '{filename}' during {operation}"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class VideoWriteError(PyAVError):
+    """Exception raised when writing video frames fails."""
+
+    def __init__(self, filename: str, operation: str, details: str | None = None) -> None:
+        message = f"Failed to write to '{filename}' during {operation}"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class ContainerError(PyAVError):
+    """Exception raised when container operations fail."""
+
+    def __init__(self, filename: str, operation: str, details: str | None = None) -> None:
+        message = f"Container operation failed for '{filename}' during {operation}"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class CodecError(PyAVError):
+    """Exception raised when codec operations fail."""
+
+    def __init__(self, filename: str, codec_name: str, details: str | None = None) -> None:
+        message = f"Codec '{codec_name}' failed for '{filename}'"
+        if details:
+            message += f": {details}"
+        super().__init__(message)
+
+
+class StreamNotFoundError(PyAVError):
+    """Exception raised when a stream is not found in a container."""
+
+    def __init__(self, filename: str, stream_type: str = "video") -> None:
+        super().__init__(f"No {stream_type} stream found in '{filename}'")
+
+
+def translate_av_error(error: Exception, filename: str = "", operation: str = "operation") -> PyAVError:  # noqa: C901
+    """Translate a PyAV/FFmpeg exception to a domain-specific exception.
+
+    Maps av.error.FFmpegError and related exceptions to appropriate
+    domain-specific PyAVError subclasses based on error context.
+
+    Args:
+        error: The original exception from PyAV/FFmpeg
+        filename: The file being operated on
+        operation: Description of the operation being performed
+
+    Returns:
+        A PyAVError subclass with contextual information
+    """
+    import av.error
+
+    error_name = type(error).__name__
+    error_str = str(error)
+
+    if isinstance(error, av.error.FFmpegError):
+        if "No such file" in error_str or "Operation not permitted" in error_str:
+            return ContainerError(filename, operation, error_str)
+
+        if "Invalid data format" in error_str or "Invalid argument" in error_str:
+            return ContainerError(filename, operation, error_str)
+
+        if "Stream not found" in error_str or "Stream does not exist" in error_str:
+            return StreamNotFoundError(filename, "video")
+
+        if "Decoder not found" in error_str or "Encoder not found" in error_str:
+            return CodecError(filename, "unknown", error_str)
+
+        if "Error while decoding" in error_str:
+            return VideoReadError(filename, operation, error_str)
+
+        if "Error while encoding" in error_str:
+            return VideoWriteError(filename, operation, error_str)
+
+        return ContainerError(filename, operation, f"{error_name}: {error_str}")
+
+    if isinstance(error, ValueError):
+        return CodecError(filename, "unknown", f"{error_str}")
+
+    if isinstance(error, (av.error.EOFError, EOFError)):
+        return VideoReadError(filename, operation, "End of file reached")
+
+    if isinstance(error, (av.error.TimeoutError, TimeoutError)):
+        return VideoReadError(filename, operation, "Operation timed out")
+
+    return PyAVError(f"{error_name}: {error_str} (file: {filename}, operation: {operation})")

--- a/src/wildcamtools/lib/rtsp.py
+++ b/src/wildcamtools/lib/rtsp.py
@@ -1,12 +1,15 @@
 import logging
 import socket
+import threading
 from pathlib import Path
-from typing import override
+from typing import Self, override
 
+import av
 import ffmpeg
 import ffmpeg.codecs.encoders
 
 from wildcamtools.lib.background_process import BackgroundProcess
+from wildcamtools.lib.errors.core import translate_av_error
 
 logger = logging.getLogger(__name__)
 
@@ -58,3 +61,76 @@ class BackgroundFFMPEGBroadcast(BackgroundProcess):
         )
         logger.debug(ffmpeg_cmd.compile_line())
         self.process = ffmpeg_cmd.run_async()
+
+
+class RTSPBroadcaster:
+    def __init__(
+        self,
+        source: str | Path,
+        rtsp_url: str,
+        loop: bool = True,
+    ):
+        self.source = Path(source).resolve()
+        self.rtsp_url = rtsp_url
+        self.loop = loop
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._broadcast_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def _broadcast_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._broadcast_once()
+                if not self.loop:
+                    break
+            except Exception:
+                if self._stop_event.is_set():
+                    break
+                logger.exception("Broadcast error")
+                if not self.loop:
+                    raise
+
+    def _broadcast_once(self) -> None:
+        try:
+            with av.open(str(self.source), mode="r") as input_container:
+                input_stream = input_container.streams.video[0]
+
+                with av.open(
+                    self.rtsp_url,
+                    mode="w",
+                    format="rtsp",
+                    options={"rtsp_transport": "tcp"},
+                ) as output_container:
+                    output_stream = output_container.add_stream("libx264", rate=input_stream.average_rate)
+                    output_stream.width = input_stream.width
+                    output_stream.height = input_stream.height
+                    output_stream.pix_fmt = "yuv420p"
+
+                    for packet in input_container.demux(input_stream):
+                        if self._stop_event.is_set():
+                            break
+                        for frame in packet.decode():
+                            output_container.mux(output_stream.encode(frame))
+
+                    output_container.mux(output_stream.encode(None))
+        except Exception as e:
+            raise translate_av_error(e, str(self.source), "RTSP broadcast") from e
+
+    def __enter__(self) -> Self:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: object | None) -> None:
+        self.stop()
+
+    # TODO: support frame iterator source in addition to file path

--- a/src/wildcamtools/lib/segment.py
+++ b/src/wildcamtools/lib/segment.py
@@ -1,30 +1,184 @@
+import logging
+from datetime import datetime
 from pathlib import Path
-from subprocess import Popen
+from typing import Any, Literal, Self
 
-import ffmpeg
-import ffmpeg.formats.muxers
+import av
+import av.container
+import av.stream
 
-from wildcamtools.lib.errors import ProcessTypeMismatchError
+from wildcamtools.lib import Frame
+from wildcamtools.lib.errors.core import (
+    VideoNotInContextError,
+    translate_av_error,
+)
+
+logger = logging.getLogger(__name__)
 
 
-def create_segment_process(*, input_: str | Path, output: str | Path, duration: float) -> Popen:
-    f = ffmpeg.input(
-        input_,
-        # demuxer_options=ffmpeg.formats.demuxers.rtsp(rtsp_transport="tcp"),
-    ).output(
-        codec="copy",
-        f="segment",
-        muxer_options=ffmpeg.formats.muxers.segment(
-            segment_time=str(duration),  # seconds
-            segment_format="mp4",
-            segment_format_options="movflags=+faststart",
-            segment_atclocktime=True,
-            reset_timestamps=True,
-            strftime=True,
-        ),
-        filename=f"{output}/seg_%Y_%m_%d__%H_%M_%S.mp4",
-    )
-    res = f.global_args(hide_banner=True, loglevel="error").overwrite_output().run_async()
-    if not isinstance(res, Popen):
-        raise ProcessTypeMismatchError()
-    return res
+class VideoSegmenter:
+    """
+    FrameSource that segments video input while emitting frames.
+
+    Uses two separate PyAV containers:
+    - Container 1: Segment muxer that writes segment files to disk
+    - Container 2: Frame decoder that emits Frame objects
+
+    This dual-container architecture allows decoding once while muxing
+    to both outputs simultaneously.
+
+    Parameters:
+        input_: Path to input video file or RTSP URL
+        segment_dir: Directory to write segment files
+        segment_duration: Duration of each segment in seconds
+        segment_pattern: Filename pattern for segments (default: seg_%Y_%m_%d__%H_%M_%S.mp4)
+        format_options: Optional dict of format options for segment muxer
+
+    TODO: Optimize to use single container with custom output callback
+          to avoid maintaining two separate container instances.
+    """
+
+    input_: str | Path
+    segment_dir: Path
+    segment_duration: float
+    segment_pattern: str
+    format_options: dict[str, str] | None
+
+    _input_container: av.container.InputContainer | None
+    _segment_container: av.container.OutputContainer | None
+    _video_stream: av.VideoStream | None
+    _frame_no: int
+    _segment_count: int
+    _last_segment_time: float
+    _segment_file: Path | None
+
+    def __init__(
+        self,
+        input_: str | Path,
+        segment_dir: str | Path,
+        segment_duration: float,
+        segment_pattern: str = "seg_%Y_%m_%d__%H_%M_%S.mp4",
+        format_options: dict[str, str] | None = None,
+    ) -> None:
+        self.input_ = input_
+        self.segment_dir = Path(segment_dir)
+        self.segment_duration = segment_duration
+        self.segment_pattern = segment_pattern
+        self.format_options = format_options
+
+        self._input_container = None
+        self._segment_container = None
+        self._video_stream = None
+        self._frame_no = 0
+        self._segment_count = 0
+        self._last_segment_time = 0.0
+        self._segment_file = None
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __enter__(self) -> Self:
+        self.segment_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._input_container = av.open(str(self.input_), mode="r")
+            self._video_stream = self._input_container.streams.video[0]
+        except Exception as e:
+            raise translate_av_error(e, str(self.input_), "opening input container") from e
+        return self
+
+    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any | None) -> Literal[False]:
+        self._close_segment_container()
+        if self._input_container:
+            try:
+                self._input_container.close()
+            except Exception:
+                logger.exception("Error closing input container")
+            self._input_container = None
+        self._video_stream = None
+        return False
+
+    def _close_segment_container(self) -> None:
+        if self._segment_container:
+            try:
+                self._segment_container.close()
+            except Exception:
+                logger.exception("Error closing segment container")
+            self._segment_container = None
+
+    def _create_segment_container(self) -> None:
+        if not self._video_stream:
+            raise VideoNotInContextError()
+
+        segment_path = str(self.segment_dir / self.segment_pattern)
+        segment_path = datetime.now().strftime(segment_path)
+
+        try:
+            self._segment_container = av.open(segment_path, mode="w")
+            output_stream = self._segment_container.add_stream(
+                codec_name="libx264",
+                rate=self._video_stream.average_rate or self._video_stream.base_rate,
+            )
+            output_stream.width = self._video_stream.width
+            output_stream.height = self._video_stream.height
+            output_stream.pix_fmt = "yuv420p"
+            output_stream.time_base = self._video_stream.time_base
+
+            if self.format_options:
+                for key, value in self.format_options.items():
+                    self._segment_container.options[key] = value
+        except Exception as e:
+            raise translate_av_error(e, segment_path, "creating segment container") from e
+
+    def _write_frame_to_segment(self, frame: av.VideoFrame) -> None:
+        if not self._segment_container or not self._video_stream:
+            return
+
+        try:
+            stream = self._segment_container.streams.video[0]
+            for packet in stream.encode(frame):
+                self._segment_container.mux(packet)
+        except Exception as e:
+            raise translate_av_error(e, str(self._segment_container.file), "muxing frame to segment") from e
+
+    def _maybe_rotate_segment(self, frame_time: float) -> None:
+        if self._segment_container is None:
+            self._create_segment_container()
+            self._last_segment_time = frame_time
+            return
+
+        if frame_time - self._last_segment_time >= self.segment_duration:
+            self._close_segment_container()
+            self._segment_count += 1
+            self._create_segment_container()
+            self._last_segment_time = frame_time
+
+    def __next__(self) -> Frame:
+        if not self._input_container or not self._video_stream:
+            raise VideoNotInContextError()
+
+        for packet in self._input_container.demux(self._video_stream):
+            try:
+                for frame in packet.decode():
+                    if not isinstance(frame, av.VideoFrame):
+                        continue
+
+                    frame_time = float(frame.time)
+                    self._maybe_rotate_segment(frame_time)
+                    self._write_frame_to_segment(frame)
+
+                    rgb_frame = frame.to_rgb().to_ndarray()
+                    result = Frame(raw=rgb_frame, frame_no=self._frame_no)
+                    self._frame_no += 1
+                    return result
+            except Exception as e:
+                raise translate_av_error(e, str(self.input_), "reading frame") from e
+
+        raise StopIteration
+
+    @property
+    def segment_count(self) -> int:
+        return self._segment_count
+
+    @property
+    def frame_count(self) -> int:
+        return self._frame_no

--- a/src/wildcamtools/lib/states.py
+++ b/src/wildcamtools/lib/states.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from wildcamtools.lib import Frame, FrameHandler
 from wildcamtools.lib.motion import MogMotion
 from wildcamtools.lib.stats import VideoStats, get_video_stats
-from wildcamtools.lib.vidio import FrameSourceFFMPEG
+from wildcamtools.lib.vidio import VideoReader
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +199,7 @@ def enqueue_motion_windows(
     def _find_motion_times(source: str, stats: VideoStats, watcher: Watcher) -> Generator[MotionWindow]:
         start_frame: int | None = None
         start_time: datetime | None = None
-        with FrameSourceFFMPEG(
+        with VideoReader(
             source,
             width=stats.x,
             height=stats.y,

--- a/src/wildcamtools/lib/vidio.py
+++ b/src/wildcamtools/lib/vidio.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from subprocess import Popen
 from typing import Any, Literal, Self
 
+import av
+import av.container
 import cv2
 import ffmpeg
 import ffmpeg.codecs.encoders
@@ -21,6 +23,7 @@ from wildcamtools.lib.errors import (
     VideoProbeError,
     VideoSizeNotSetError,
 )
+from wildcamtools.lib.errors.core import StreamNotFoundError, translate_av_error
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +221,141 @@ class FrameSourceFFMPEG(FrameSource):
         self.cumulative_time += end - start
 
         return frame
+
+
+class VideoReader(FrameSource):
+    """PyAV-based video reader with frame scaling and FPS control.
+
+    Uses PyAV for direct library access without subprocess or named pipes.
+    """
+
+    filename: Path | str
+    width: int | None
+    height: int | None
+    scale: float
+    fps: float
+    frame_no: int
+    hwaccel: str | None
+
+    _container: av.container.InputContainer | None
+    _stream: av.VideoStream | None
+    _target_fps: float | None
+    _last_pts: float | None
+
+    def __init__(
+        self,
+        filename: Path | str,
+        width: int | None = None,
+        height: int | None = None,
+        scale: float = 1.0,
+        fps: float = -1.0,
+        hwaccel: str | None = None,
+    ):
+        super().__init__()
+        self.filename = filename
+        self.width = width
+        self.height = height
+        self.scale = scale
+        self.fps = fps
+        self.hwaccel = hwaccel
+        self.frame_no = 0
+        self._container = None
+        self._stream = None
+        self._target_fps = None
+        self._last_pts = None
+
+        if hwaccel is not None:
+            logger.warning("Hardware acceleration (hwaccel) is not yet implemented")
+
+    def __enter__(self) -> Self:
+        try:
+            self._container = av.open(self.filename)
+            self._stream = self._container.streams.video[0]
+        except av.error.FFmpegError as e:
+            raise translate_av_error(e, str(self.filename), "open") from e
+        except (KeyError, IndexError) as e:
+            raise StreamNotFoundError(str(self.filename), "video") from e
+
+        if self.width is None or self.height is None:
+            self._detect_dimensions()
+
+        if self.fps > 0.0:
+            self._target_fps = self.fps
+        else:
+            self._target_fps = None
+
+        self._last_pts = None
+        self.frame_no = 0
+        return self
+
+    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any | None) -> Literal[False]:
+        if self._container:
+            self._container.close()
+        self._container = None
+        self._stream = None
+        self._target_fps = None
+        self._last_pts = None
+        return False
+
+    def _detect_dimensions(self) -> None:
+        if not self._stream:
+            raise VideoNotInContextError()
+        self.width = int(self._stream.width * self.scale)
+        self.height = int(self._stream.height * self.scale)
+
+    def __next__(self) -> Frame:
+        if not self._container or not self._stream:
+            raise VideoNotInContextError()
+
+        if not self.width or not self.height:
+            raise VideoSizeNotSetError()
+
+        try:
+            for packet in self._container.demux(self._stream):
+                for frame in packet.decode():
+                    if self._should_drop_frame(frame):
+                        continue
+
+                    rgb_frame = frame.to_ndarray(format="rgb24")
+
+                    if self.scale != 1.0:
+                        rgb_frame = cv2.resize(  # type: ignore[assignment]
+                            rgb_frame,
+                            (self.width, self.height),
+                            interpolation=cv2.INTER_LINEAR,
+                        )
+
+                    result = Frame(raw=rgb_frame, frame_no=self.frame_no)
+                    self.frame_no += 1
+                    return result
+
+            raise StopIteration
+        except av.error.FFmpegError as e:
+            raise translate_av_error(e, str(self.filename), "read frame") from e
+        except EOFError as e:
+            raise StopIteration from e
+
+    def _should_drop_frame(self, frame: av.VideoFrame) -> bool:
+        if self._target_fps is None:
+            return False
+
+        if not self._stream or not self._stream.time_base:
+            return False
+
+        current_pts = frame.time * float(self._stream.time_base)
+
+        if self._last_pts is None:
+            self._last_pts = current_pts
+            return False
+
+        min_interval = 1.0 / self._target_fps
+        elapsed = current_pts - self._last_pts
+
+        if elapsed < min_interval:
+            return True
+
+        self._last_pts = current_pts
+        return False
 
 
 class FrameSourceFFMPEGSegmenter(FrameSource):

--- a/src/wildcamtools/lib/vidio.py
+++ b/src/wildcamtools/lib/vidio.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from subprocess import Popen
 from typing import Any, Literal, Self
 
+import av
 import cv2
 import ffmpeg
 import ffmpeg.codecs.encoders
@@ -20,6 +21,8 @@ from wildcamtools.lib.errors import (
     VideoNotInContextError,
     VideoProbeError,
     VideoSizeNotSetError,
+    VideoWriteError,
+    translate_av_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -359,3 +362,118 @@ class FrameWriterFFMPEG:
     def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any | None) -> Literal[False]:
         self.close()
         return False
+
+
+class VideoWriter:
+    """
+    Context-managed video writer using PyAV for direct library access.
+    Accepts numpy arrays (HxWx3 RGB or HxWx4 RGBA) and writes to video files.
+    """
+
+    # TODO: Add hardware acceleration support (e.g., h264_nvenc, h264_vaapi)
+
+    def __init__(
+        self,
+        out_filename: Path | str,
+        fps: float,
+        codec: str = "libx264",
+        crf: int = 23,
+        preset: str = "medium",
+        pix_fmt: str = "yuv420p",
+    ):
+        self.out_filename = Path(out_filename)
+        self.fps = fps
+        self.codec = codec
+        self.crf = crf
+        self.preset = preset
+        self.pix_fmt = pix_fmt
+
+        self._container: av.container.OutputContainer | None = None
+        self._stream: av.video.stream.VideoStream | None = None
+        self._width: int | None = None
+        self._height: int | None = None
+        self._started = False
+        self._frame_count = 0
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any | None) -> Literal[False]:
+        self.close()
+        return False
+
+    def write(self, frame: np.ndarray) -> None:
+        """
+        Write a single frame to the output video.
+        Infers dimensions from the first frame.
+        """
+        if frame.ndim == 2:
+            frame = np.stack((frame,) * 3, axis=-1)
+
+        h, w, ch = frame.shape
+        if ch == 4:
+            frame = frame[:, :, :3]
+
+        if not self._started:
+            self._width = w
+            self._height = h
+            self._open_container()
+
+        if frame.shape[0] != (self._height or 0) or frame.shape[1] != (self._width or 0):
+            frame = cv2.resize(frame, (int(self._width or 0), int(self._height or 0)), interpolation=cv2.INTER_LINEAR)
+
+        self._write_frame(frame)
+
+    def _open_container(self) -> None:
+        if self._width is None or self._height is None:
+            raise VideoSizeNotSetError()
+
+        logger.debug(f"Opening video writer for {self.out_filename} (codec={self.codec}, fps={self.fps})")
+        self._container = av.open(str(self.out_filename), mode="w")
+        stream = self._container.add_stream(self.codec, rate=int(self.fps))
+        if not isinstance(stream, av.video.stream.VideoStream):
+            raise VideoWriteError(str(self.out_filename), "opening container", "Expected video stream")
+        self._stream = stream
+        self._stream.width = self._width
+        self._stream.height = self._height
+        self._stream.pix_fmt = self.pix_fmt
+        self._stream.options = {"crf": str(self.crf), "preset": self.preset}
+        self._started = True
+        logger.debug(f"Video writer opened: {self._width}x{self._height}")
+
+    def _write_frame(self, frame: np.ndarray) -> None:
+        if not self._container or not self._stream:
+            raise VideoWriteError(str(self.out_filename), "writing frame", "Container or stream not initialized")
+
+        try:
+            av_frame = av.VideoFrame.from_ndarray(frame, format="rgb24")
+            av_frame.pts = self._frame_count
+            self._frame_count += 1
+
+            packets = self._stream.encode(av_frame)
+            for packet in packets:
+                self._container.mux(packet)
+        except Exception as e:
+            logger.exception("Failed to write frame %d to %s", self._frame_count, self.out_filename)
+            raise translate_av_error(e, str(self.out_filename), "writing frame") from e
+
+    def close(self) -> None:
+        """Flush encoder and close container."""
+        if not self._container or not self._stream:
+            return
+
+        try:
+            packets = self._stream.encode(None)
+            for packet in packets:
+                self._container.mux(packet)
+
+            self._container.close()
+        except Exception as e:
+            logger.warning(f"Error closing video writer: {e}")
+        finally:
+            self._container = None
+            self._stream = None
+            self._started = False
+            self._width = None
+            self._height = None
+            self._frame_count = 0


### PR DESCRIPTION
## Summary
Update all CLI modules and samples to use new PyAV-based helper classes.

## Changes
- `cli/motion_mog2.py`: FrameSourceFFMPEG → VideoReader, FrameWriterFFMPEG → VideoWriter
- `cli/frames.py`: FrameSourceFFMPEG → VideoReader
- `cli/perftest.py`: FrameSourceFFMPEG → VideoReader, FrameWriterFFMPEG → VideoWriter
- `cli/rescale.py`: FrameSourceFFMPEG → VideoReader, FrameWriterFFMPEG → VideoWriter
- `cli/rtsp.py`: BackgroundFFMPEGBroadcast → RTSPBroadcaster
- `lib/states.py`: FrameSourceFFMPEG → VideoReader
- `samples/create.py`: Remove ffmpeg-python, use PyAV directly

## Dependencies
- Depends on #33 (Add PyAV dependency)
- Depends on error handling framework
- Depends on VideoReader, VideoWriter, RTSPBroadcaster implementations

## Testing
- Passes ruff check and mypy
- Integration tests in final phase

## Next Steps
Final cleanup: remove old implementation classes and typed-ffmpeg dependency