### PR TITLE
feat: add Ollama backend support to AI analyzer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+  "ollama>=0.6.2",
   "openai>=2.32.0",
   "opencv-contrib-python-headless>=4.12.0.88",
   "pillow>=12.1.0",

--- a/src/wildcamtools/cli/ai.py
+++ b/src/wildcamtools/cli/ai.py
@@ -1,31 +1,44 @@
 import json
+from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
+from wildcamtools.lib.ai import AbstractAnalyser
 from wildcamtools.lib.ai.llamacpp import LlamaCppAnalyser
+from wildcamtools.lib.ai.ollama import OllamaAnalyser
 from wildcamtools.lib.errors.cli import InputNotDirectoryError
 from wildcamtools.lib.timing import Timer
 
 app = typer.Typer()
 
 
+class Backend(str, Enum):
+    LLAMACPP = "llamacpp"
+    OLLAMA = "ollama"
+
+
 @app.command()
-def llamacpp(
+def analyze(
     input_: Annotated[Path, typer.Argument(metavar="INPUT")],
-    url: str,
-    model: str,
+    model: Annotated[str, typer.Option(help="Model name to use")],
+    backend: Annotated[Backend, typer.Option(help="Backend to use")] = Backend.LLAMACPP,
+    url: Annotated[str, typer.Option(help="Base URL for the backend")] = "http://localhost:8080/v1",
+    api_key: Annotated[str | None, typer.Option(help="API key for ollama backend")] = None,
     output: Annotated[Path | None, typer.Option(metavar="OUTPUT")] = None,
 ) -> None:
     if input_.exists() and not input_.is_dir():
         raise InputNotDirectoryError()
-    # TODO filter on files, image endings
     images = list(input_.iterdir())
-    # TODO error if no image found
 
     timer = Timer()
-    analyser = LlamaCppAnalyser(model=model, base_url=url)
+    analyser: AbstractAnalyser
+    match backend:
+        case Backend.LLAMACPP:
+            analyser = LlamaCppAnalyser(model=model, base_url=url)
+        case Backend.OLLAMA:
+            analyser = OllamaAnalyser(model=model, host=url, api_key=api_key)
 
     with timer:
         result = analyser.analyze_video(images)

--- a/src/wildcamtools/lib/ai/ollama.py
+++ b/src/wildcamtools/lib/ai/ollama.py
@@ -1,0 +1,51 @@
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+import ollama as ollama_lib
+
+from wildcamtools.lib.ai import AbstractAnalyser
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaAnalyser(AbstractAnalyser):
+    message: str = "This is a video image from a UK garden near a river. Is there an animal in this image, if so what? answer only 'no' or the common English name of the species."
+    client: ollama_lib.Client
+    model: str
+
+    def __init__(
+        self,
+        model: str = "qwen3.5:cloud",
+        api_key: str | None = None,
+        host: str = "https://ollama.com",
+        message: str | None = None,
+    ) -> None:
+        if message is not None:
+            self.message = message
+        self.client = ollama_lib.Client(
+            host=host,
+            headers={"Authorization": f"Bearer {api_key}"} if api_key else {},
+        )
+        self.model = model
+
+    def analyze_video(self, images: Iterable[Path]) -> str:
+        image_bytes = [image.read_bytes() for image in images]
+        logger.info("Loaded %d images for analysis", len(image_bytes))
+
+        messages = [
+            {
+                "role": "user",
+                "content": self.message,
+                "images": image_bytes,
+            },
+        ]
+        logger.info("Sending %d images to %s model", len(image_bytes), self.model)
+        response = self.client.chat(
+            self.model,
+            messages=messages,
+            options={"seed": 42, "temperature": 0},
+            keep_alive=60.0,
+        )
+        logger.info("Analysis result: %s", response.message.content)
+        return response.message.content or ""

--- a/uv.lock
+++ b/uv.lock
@@ -579,6 +579,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,6 +1444,7 @@ name = "wildcamtools"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "ollama" },
     { name = "openai" },
     { name = "opencv-contrib-python-headless" },
     { name = "pillow" },
@@ -1458,6 +1472,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ollama", specifier = ">=0.6.2" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "opencv-contrib-python-headless", specifier = ">=4.12.0.88" },
     { name = "pillow", specifier = ">=12.1.0" },


### PR DESCRIPTION
## Summary
- Add OllamaAnalyser class for Ollama vision model integration
- Update CLI `ai analyze` command with `--backend` option (llamacpp or ollama)
- Use enum type for backend selection with proper type safety
- Add ollama dependency

## Changes
- `src/wildcamtools/lib/ai/ollama.py`: New OllamaAnalyser implementing AbstractAnalyser
- `src/wildcamtools/cli/ai.py`: Refactored to support multiple backends with --backend flag
- `pyproject.toml`: Added ollama dependency

## Testing
- Passes ruff format, ruff check, and mypy