### PR TITLE
refactor: wrap AI evaluate functions with richer dataclass interfaces

### DIFF
--- a/src/wildcamtools/cli/ai.py
+++ b/src/wildcamtools/cli/ai.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 import typer
 
 from wildcamtools.lib.ai import AbstractAnalyser, Backend
-from wildcamtools.lib.ai.evaluate import create_frames, evaluate_frames
+from wildcamtools.lib.ai.evaluate import AIEvaluation, AIFrameCreation, create_frames, evaluate_frames
 from wildcamtools.lib.ai.llamacpp import LlamaCppAnalyser
 from wildcamtools.lib.ai.ollama import OllamaAnalyser
 from wildcamtools.lib.errors.cli import InputNotDirectoryError
@@ -121,10 +121,15 @@ def evaluate(
         for parameter_dict in parameter_dicts:
             for filename in labelled_data:
                 frame_directory = TemporaryDirectory()
+                frame_creation = AIFrameCreation(
+                    filename=Path(filename),
+                    video_directory=video_directory,
+                    tmpdir=Path(frame_directory.name),
+                    **parameter_dict,
+                )
                 future = pool.apply_async(
                     create_frames,
-                    args=(video_directory / filename, video_directory, Path(frame_directory.name)),
-                    kwds=parameter_dict,
+                    args=(frame_creation,),
                 )
                 futures.append((future, filename, frame_directory, parameter_dict))
 
@@ -132,41 +137,45 @@ def evaluate(
         for future, filename, frame_directory, parameter_dict in futures:
             # as image generation finishes, detect and compare to label
             # use get() with a None return to ensure exceptions are raised
-            future.get()
+            frame_creation_result = future.get()
 
             label = labelled_data[filename]
-            result = evaluate_frames(
-                Path(frame_directory.name),
-                label,
-                backend,
-                url,
-                model,
-                api_key=api_key if api_key else "API_KEY",
-                prompt=prompt,
+            evaluated_result = evaluate_frames(
+                AIEvaluation(
+                    frame_directory=Path(frame_directory.name),
+                    label=label,
+                    backend=backend,
+                    url=url,
+                    model=model,
+                    api_key=api_key if api_key else "API_KEY",
+                    prompt=prompt,
+                )
             )
-            logger.info("File %s correct? %s", filename, result)
+            logger.info("File %s correct? %s", filename, evaluated_result.correct)
 
             counter_key = tuple(sorted(parameter_dict.items()))
             if counter_key not in counters:
                 counters[counter_key] = [0, 0]
-            counters[counter_key][0] += 1 if result else 0
+            counters[counter_key][0] += 1 if evaluated_result.correct else 0
             counters[counter_key][1] += 1
 
             # TODO parameterize filename
             with open("result.jsonl", "a") as result_file:
-                out_dict = dict(parameter_dict)
-                out_dict["filename"] = filename
-                out_dict["model"] = model
-                # this is a tuple of a dictionary of fixed variables and a dictionary of unknown result variables
-                result_out = (
-                    out_dict,
-                    {
-                        "result": result,
-                        "label": label,
-                        # TODO add more variables here e.g. frame count, motion proportion (min,q1,median,q2,max)
-                    },
+                output_parameter_dict = dict(parameter_dict)
+                output_parameter_dict["filename"] = filename
+                output_parameter_dict["model"] = model
+                result_dict = {
+                    "result": evaluated_result.correct,
+                    "raw_result": evaluated_result.raw_result,
+                    "label": label,
+                    "frame_count": frame_creation_result.frame_count,
+                    # TODO add more variables here e.g. motion proportion (min,q1,median,q2,max)
+                }
+                output_dict = (
+                    output_parameter_dict,
+                    result_dict,
                 )
-                result_file.write(json.dumps(result_out))
+                result_file.write(json.dumps(output_dict))
                 result_file.write("\n")
 
             # now cleanup the frames

--- a/src/wildcamtools/lib/ai/evaluate.py
+++ b/src/wildcamtools/lib/ai/evaluate.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from wildcamtools.lib import FrameHandler
@@ -13,77 +16,139 @@ from wildcamtools.lib.vidio import VideoReader
 logger = logging.getLogger(__name__)
 
 
+@dataclass(kw_only=True)
+class AIFrameCreation:
+    filename: Path
+    video_directory: Path
+    tmpdir: Path
+    history: int = 30
+    threshold: float = 16.0
+    kernel_size: float = 0.02
+    x: int | None = None
+    y: int | None = None
+    fps: float | None = None
+    crop_expansion: float = 0.75
+    crop_inertia: float = 10.0
+    similarity_minimum: float | None = None
+    do_croppan: bool = False
+
+
+@dataclass(kw_only=True)
+class AIFrameCreationResult(AIFrameCreation):
+    frame_count: int
+
+    @classmethod
+    def from_creation(cls, creation: AIFrameCreation, *, frame_count: int) -> AIFrameCreationResult:
+        return cls(
+            filename=creation.filename,
+            video_directory=creation.video_directory,
+            tmpdir=creation.tmpdir,
+            history=creation.history,
+            threshold=creation.threshold,
+            kernel_size=creation.kernel_size,
+            x=creation.x,
+            y=creation.y,
+            fps=creation.fps,
+            crop_expansion=creation.crop_expansion,
+            crop_inertia=creation.crop_inertia,
+            similarity_minimum=creation.similarity_minimum,
+            do_croppan=creation.do_croppan,
+            frame_count=frame_count,
+        )
+
+
+@dataclass(kw_only=True)
+class AIEvaluation:
+    frame_directory: Path
+    label: str
+    backend: Backend
+    url: str
+    model: str
+    api_key: str = "API_KEY"
+    prompt: str | None = None
+
+
+@dataclass(kw_only=True)
+class AIEvaluationResult(AIEvaluation):
+    correct: bool
+    raw_result: str
+
+    @classmethod
+    def from_evaluation(cls, evaluation: AIEvaluation, *, correct: bool, raw_result: str) -> AIEvaluationResult:
+        return cls(
+            frame_directory=evaluation.frame_directory,
+            label=evaluation.label,
+            backend=evaluation.backend,
+            url=evaluation.url,
+            model=evaluation.model,
+            api_key=evaluation.api_key,
+            prompt=evaluation.prompt,
+            correct=correct,
+            raw_result=raw_result,
+        )
+
+
 def create_frames(
-    filename: Path,
-    video_directory: Path,
-    tmpdir: Path,
-    history: int = 30,
-    threshold: float = 16.0,
-    kernel_size: float = 0.02,
-    x: int | None = None,
-    y: int | None = None,
-    fps: float | None = None,
-    crop_expansion: float = 0.75,
-    crop_inertia: float = 10.0,
-    similarity_minimum: float | None = None,
-    do_croppan: bool = False,
-) -> None:
-    stats = get_video_stats(video_directory / filename)
+    frame_creation: AIFrameCreation,
+) -> AIFrameCreationResult:
+    stats = get_video_stats(frame_creation.video_directory / frame_creation.filename)
     handlers: list[FrameHandler] = []
 
-    if do_croppan:
+    if frame_creation.do_croppan:
         handlers.append(
             CropPanHandler(
                 motion_handler=MogMotion(
-                    history=history,
-                    threshold=int(threshold),
-                    kernel_size=kernel_size,
+                    history=frame_creation.history,
+                    threshold=int(frame_creation.threshold),
+                    kernel_size=frame_creation.kernel_size,
                 ),
-                expansion=crop_expansion,
-                inertia=crop_inertia,
+                expansion=frame_creation.crop_expansion,
+                inertia=frame_creation.crop_inertia,
             )
         )
     # TODO rescale after similarity vs rescale before similarity
-    if x or y or fps:
+    if frame_creation.x or frame_creation.y or frame_creation.fps:
         handlers.append(
             Rescaler(
                 stats=stats,
-                x=x,
-                y=y,
-                fps=fps,
+                x=frame_creation.x,
+                y=frame_creation.y,
+                fps=frame_creation.fps,
             )
         )
 
-    if similarity_minimum is not None:
-        handlers.append(FilterSSIM(similarity_minimum=similarity_minimum))
+    if frame_creation.similarity_minimum is not None:
+        handlers.append(FilterSSIM(similarity_minimum=frame_creation.similarity_minimum))
 
-    handlers.append(FrameImageWriter(Path(tmpdir)))
+    handlers.append(FrameImageWriter(frame_creation.tmpdir))
 
-    with VideoReader(video_directory / filename) as video_input:
-        for frame in video_input:
+    frame_count = 0
+    with VideoReader(frame_creation.video_directory / frame_creation.filename) as video_input:
+        for _frame in video_input:
+            frame_count += 1
             for handler in handlers:
-                frame = handler.handle(frame)
+                _frame = handler.handle(_frame)
+
+    return AIFrameCreationResult.from_creation(frame_creation, frame_count=frame_count)
 
 
 def evaluate_frames(
-    frame_directory: Path,
-    label: str,
-    backend: Backend,
-    url: str,
-    model: str,
-    api_key: str = "API_KEY",
-    prompt: str | None = None,
-) -> bool:
+    evaluation: AIEvaluation,
+) -> AIEvaluationResult:
     analyser: AbstractAnalyser
-    match backend:
+    match evaluation.backend:
         case Backend.LLAMACPP:
-            analyser = LlamaCppAnalyser(model=model, base_url=url, message=prompt)
+            analyser = LlamaCppAnalyser(model=evaluation.model, base_url=evaluation.url, message=evaluation.prompt)
         case Backend.OLLAMA:
-            analyser = OllamaAnalyser(model=model, host=url, api_key=api_key, message=prompt)
+            analyser = OllamaAnalyser(
+                model=evaluation.model, host=evaluation.url, api_key=evaluation.api_key, message=evaluation.prompt
+            )
         case _:
-            raise ValueError(f"Unsupported backend: {backend}")
+            raise ValueError(f"Unsupported backend: {evaluation.backend}")
 
-    images = list(frame_directory.iterdir())
-    result = analyser.analyze_video(images) if images else "no"
-    logger.info("Label: %s Result: %s", label, result)
-    return label.lower() == result.lower()
+    images = list(evaluation.frame_directory.iterdir())
+    raw_result = analyser.analyze_video(images) if images else "no"
+    logger.info("Label: %s Result: %s", evaluation.label, raw_result)
+    correct = evaluation.label.lower() == raw_result.lower()
+
+    return AIEvaluationResult.from_evaluation(evaluation, correct=correct, raw_result=raw_result)


### PR DESCRIPTION
## Summary

- Introduces `AIFrameCreation` / `AIFrameCreationResult` and `AIEvaluation` / `AIEvaluationResult` dataclass hierarchies in `evaluate.py`
- `create_frames()` and `evaluate_frames()` now accept a single input object and return a result object instead of `None`/`bool`
- Result classes carry `classmethod` factories (`from_creation`, `from_evaluation`) for explicit construction
- `AIFrameCreationResult` includes `frame_count`; `AIEvaluationResult` includes `correct` and `raw_result`
- CLI caller in `ai.py` updated for the new signatures