### PR TITLE
feat: add frame tiling with overlap support for AI analysis

### DIFF
--- a/src/wildcamtools/cli/ai.py
+++ b/src/wildcamtools/cli/ai.py
@@ -4,12 +4,18 @@ import multiprocessing
 from multiprocessing.pool import AsyncResult
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import typer
 
 from wildcamtools.lib.ai import AbstractAnalyser, Backend
-from wildcamtools.lib.ai.evaluate import AIEvaluation, AIFrameCreation, create_frames, evaluate_frames
+from wildcamtools.lib.ai.evaluate import (
+    AIEvaluation,
+    AIFrameCreation,
+    AIFrameCreationResult,
+    create_frames,
+    evaluate_frames,
+)
 from wildcamtools.lib.ai.llamacpp import LlamaCppAnalyser
 from wildcamtools.lib.ai.ollama import OllamaAnalyser
 from wildcamtools.lib.errors.cli import InputNotDirectoryError
@@ -31,6 +37,124 @@ def _read_prompt_file(prompt_file: Path | None) -> str | None:
         logger.warning("Prompt file %s is empty, using default prompt", prompt_file)
         return None
     return prompt
+
+
+def _validate_tiling_parameters(
+    tiling_cols: int | None,
+    tiling_rows: int | None,
+    tiling_overlap: float | None,
+) -> tuple[int | None, int | None, float | None]:
+    """Validate tiling parameters and exit with error if invalid."""
+    if tiling_cols is not None and tiling_cols < 1:
+        typer.secho("Error: --tiling-cols must be at least 1", err=True)
+        raise typer.Exit(code=1)
+    if tiling_rows is not None and tiling_rows < 1:
+        typer.secho("Error: --tiling-rows must be at least 1", err=True)
+        raise typer.Exit(code=1)
+    if tiling_overlap is not None and (tiling_overlap < 0.0 or tiling_overlap >= 1.0):
+        typer.secho("Error: --tiling-overlap must be between 0.0 and 1.0", err=True)
+        raise typer.Exit(code=1)
+    if tiling_cols is not None and tiling_rows is None:
+        tiling_rows = 1
+    if tiling_rows is not None and tiling_cols is None:
+        tiling_cols = 1
+    return tiling_cols, tiling_rows, tiling_overlap
+
+
+def _build_evaluate_parameters(
+    kernel_size: float,
+    threshold: int,
+    history: int,
+    crop_expansion: float,
+    crop_inertia: float,
+    x: int | None,
+    y: int | None,
+    fps: float | None,
+    similarity_minimum: float | None,
+    tiling_cols: int | None,
+    tiling_rows: int | None,
+    tiling_overlap: float | None,
+) -> list[dict[str, Any]]:
+    """Build list of parameter dictionaries for frame creation."""
+    parameter_dicts: list[dict[str, Any]] = []
+    parameter_dicts.append({
+        "kernel_size": kernel_size,
+        "threshold": threshold,
+        "history": history,
+        "crop_expansion": crop_expansion,
+        "crop_inertia": crop_inertia,
+        "x": x,
+        "y": y,
+        "fps": fps,
+        "similarity_minimum": similarity_minimum,
+        "tiling_cols": tiling_cols,
+        "tiling_rows": tiling_rows,
+        "tiling_overlap": tiling_overlap,
+    })
+    return parameter_dicts
+
+
+def _process_frame_result(
+    future: tuple[AsyncResult, str, TemporaryDirectory[str], dict[str, Any]],
+    labelled_data: dict[str, Any],
+    backend: Backend,
+    url: str,
+    model: str,
+    api_key: str | None,
+    prompt: str | None,
+    counters: dict[tuple[Any, ...], list[int]],
+) -> None:
+    """Process a single frame result, evaluate it, and write to result file."""
+    future_result, filename, frame_directory, parameter_dict = future
+    frame_creation_result = cast(AIFrameCreationResult, future_result.get())
+
+    label = labelled_data[filename]
+    evaluated_result = evaluate_frames(
+        AIEvaluation(
+            frame_directory=Path(frame_directory.name),
+            label=label,
+            backend=backend,
+            url=url,
+            model=model,
+            api_key=api_key if api_key else "API_KEY",
+            prompt=prompt,
+        )
+    )
+    logger.info("File %s correct? %s", filename, evaluated_result.correct)
+
+    counter_key = tuple(sorted(parameter_dict.items()))
+    if counter_key not in counters:
+        counters[counter_key] = [0, 0]
+    counters[counter_key][0] += 1 if evaluated_result.correct else 0
+    counters[counter_key][1] += 1
+
+    with open("result.jsonl", "a") as result_file:
+        output_parameter_dict = dict(parameter_dict)
+        output_parameter_dict["filename"] = filename
+        output_parameter_dict["model"] = model
+        result_dict = {
+            "result": evaluated_result.correct,
+            "raw_result": evaluated_result.raw_result,
+            "label": label,
+            "frame_count": frame_creation_result.frame_count,
+        }
+        output_dict = (
+            output_parameter_dict,
+            result_dict,
+        )
+        result_file.write(json.dumps(output_dict))
+        result_file.write("\n")
+
+    frame_directory.cleanup()
+
+
+def _print_evaluation_summary(counters: dict[tuple[Any, ...], list[int]]) -> None:
+    """Print evaluation summary statistics."""
+    for counter_key in counters:
+        successes = counters[counter_key][0]
+        attempts = counters[counter_key][1]
+        ratio = successes / attempts
+        typer.secho(f"{counter_key}: {successes} / {attempts} = {ratio:.4f}")
 
 
 @app.command()
@@ -80,6 +204,7 @@ def evaluate(
     url: Annotated[str, typer.Option(help="Base URL for the backend")] = "http://localhost:8080/v1",
     api_key: Annotated[str | None, typer.Option(help="API key for ollama backend")] = None,
     history: int = 30,
+    threshold: int = 16,
     kernel_size: float = 0.02,
     x: int | None = None,
     y: int | None = None,
@@ -87,34 +212,32 @@ def evaluate(
     crop_expansion: float = 0.75,
     crop_inertia: float = 10.0,
     similarity_minimum: float | None = None,
+    tiling_cols: Annotated[int | None, typer.Option(help="Number of horizontal tiles per frame")] = None,
+    tiling_rows: Annotated[int | None, typer.Option(help="Number of vertical tiles per frame")] = None,
+    tiling_overlap: Annotated[float | None, typer.Option(help="Overlap proportion between tiles (0.0-1.0)")] = None,
     prompt_file: Annotated[Path | None, typer.Option(help="Path to a text file containing the prompt")] = None,
 ) -> None:
+    tiling_cols, tiling_rows, tiling_overlap = _validate_tiling_parameters(tiling_cols, tiling_rows, tiling_overlap)
     prompt = _read_prompt_file(prompt_file)
 
-    # read json lines
     labelled_data = load_labels(labels)
     video_directory = labels.resolve().parent
 
-    # build a big ol' list of what we want to run
-    parameter_dicts: list[dict[str, Any]] = []
-    # TODO parameterize kernel_size as a reciprocal (e.g 1/100, 1/200, etc)
-    for kernel_size in [0.01]:  # [0.02, 0.015, 0.01, 0.0075, 0.005]:
-        for threshold in [16]:  # [8, 16, 24, 32, 48, 64]:
-            parameter_dicts.append({
-                "kernel_size": kernel_size,
-                "threshold": threshold,
-                "history": history,
-                "crop_expansion": crop_expansion,
-                "crop_inertia": crop_inertia,
-                "x": x,
-                "y": y,
-                "fps": fps,
-                "similarity_minimum": similarity_minimum,
-                # "do_croppan": True,
-            })
+    parameter_dicts = _build_evaluate_parameters(
+        kernel_size=kernel_size,
+        threshold=threshold,
+        history=history,
+        crop_expansion=crop_expansion,
+        crop_inertia=crop_inertia,
+        x=x,
+        y=y,
+        fps=fps,
+        similarity_minimum=similarity_minimum,
+        tiling_cols=tiling_cols,
+        tiling_rows=tiling_rows,
+        tiling_overlap=tiling_overlap,
+    )
 
-    # run image generation in parallel
-    # use "spawn" rather than default "fork" for opencv compatibility
     ctx = multiprocessing.get_context("spawn")
     with ctx.Pool() as pool:
         futures: list[tuple[AsyncResult, str, TemporaryDirectory[str], dict[str, Any]]] = []
@@ -134,55 +257,16 @@ def evaluate(
                 futures.append((future, filename, frame_directory, parameter_dict))
 
         counters: dict[tuple[Any, ...], list[int]] = {}
-        for future, filename, frame_directory, parameter_dict in futures:
-            # as image generation finishes, detect and compare to label
-            # use get() with a None return to ensure exceptions are raised
-            frame_creation_result = future.get()
-
-            label = labelled_data[filename]
-            evaluated_result = evaluate_frames(
-                AIEvaluation(
-                    frame_directory=Path(frame_directory.name),
-                    label=label,
-                    backend=backend,
-                    url=url,
-                    model=model,
-                    api_key=api_key if api_key else "API_KEY",
-                    prompt=prompt,
-                )
+        for future_tuple in futures:
+            _process_frame_result(
+                future=future_tuple,
+                labelled_data=labelled_data,
+                backend=backend,
+                url=url,
+                model=model,
+                api_key=api_key,
+                prompt=prompt,
+                counters=counters,
             )
-            logger.info("File %s correct? %s", filename, evaluated_result.correct)
 
-            counter_key = tuple(sorted(parameter_dict.items()))
-            if counter_key not in counters:
-                counters[counter_key] = [0, 0]
-            counters[counter_key][0] += 1 if evaluated_result.correct else 0
-            counters[counter_key][1] += 1
-
-            # TODO parameterize filename
-            with open("result.jsonl", "a") as result_file:
-                output_parameter_dict = dict(parameter_dict)
-                output_parameter_dict["filename"] = filename
-                output_parameter_dict["model"] = model
-                result_dict = {
-                    "result": evaluated_result.correct,
-                    "raw_result": evaluated_result.raw_result,
-                    "label": label,
-                    "frame_count": frame_creation_result.frame_count,
-                    # TODO add more variables here e.g. motion proportion (min,q1,median,q2,max)
-                }
-                output_dict = (
-                    output_parameter_dict,
-                    result_dict,
-                )
-                result_file.write(json.dumps(output_dict))
-                result_file.write("\n")
-
-            # now cleanup the frames
-            frame_directory.cleanup()
-
-    for counter_key in counters:
-        successes = counters[counter_key][0]
-        attempts = counters[counter_key][1]
-        ratio = successes / attempts
-        typer.secho(f"{counter_key}: {successes} / {attempts} = {ratio:.4f}")
+    _print_evaluation_summary(counters)

--- a/src/wildcamtools/lib/__init__.py
+++ b/src/wildcamtools/lib/__init__.py
@@ -19,6 +19,11 @@ class Frame:
     crop: cv2.typing.MatLike | None = None
     rescale: cv2.typing.MatLike | None = None
     crop_bbox: BBox | None = None
+    tiles: list[cv2.typing.MatLike] | None = None
+    tiling_cols: int | None = None
+    tiling_rows: int | None = None
+    tiling_width: int | None = None
+    tiling_height: int | None = None
 
     @property
     def output(self) -> cv2.typing.MatLike:
@@ -69,6 +74,14 @@ class Frame:
         if self.crop is not None:
             return int(self.crop.shape[0])
         return self.height_raw
+
+    def get_tile(self, x: int, y: int) -> cv2.typing.MatLike | None:
+        if self.tiles is None or self.tiling_cols is None or self.tiling_rows is None:
+            return None
+        if x < 0 or x >= self.tiling_cols or y < 0 or y >= self.tiling_rows:
+            return None
+        index = y * self.tiling_cols + x
+        return self.tiles[index]
 
 
 @dataclass(frozen=True)

--- a/src/wildcamtools/lib/ai/evaluate.py
+++ b/src/wildcamtools/lib/ai/evaluate.py
@@ -8,7 +8,7 @@ from wildcamtools.lib import FrameHandler
 from wildcamtools.lib.ai import AbstractAnalyser, Backend
 from wildcamtools.lib.ai.llamacpp import LlamaCppAnalyser
 from wildcamtools.lib.ai.ollama import OllamaAnalyser
-from wildcamtools.lib.frames import CropPanHandler, FilterSSIM, FrameImageWriter, Rescaler
+from wildcamtools.lib.frames import CropPanHandler, FilterSSIM, FrameImageWriter, FrameTiler, Rescaler
 from wildcamtools.lib.motion import MogMotion
 from wildcamtools.lib.stats import get_video_stats
 from wildcamtools.lib.vidio import VideoReader
@@ -31,11 +31,15 @@ class AIFrameCreation:
     crop_inertia: float = 10.0
     similarity_minimum: float | None = None
     do_croppan: bool = False
+    tiling_cols: int | None = None
+    tiling_rows: int | None = None
+    tiling_overlap: float | None = None
 
 
 @dataclass(kw_only=True)
 class AIFrameCreationResult(AIFrameCreation):
     frame_count: int
+    tiling_overlap: float | None = None
 
     @classmethod
     def from_creation(cls, creation: AIFrameCreation, *, frame_count: int) -> AIFrameCreationResult:
@@ -53,6 +57,9 @@ class AIFrameCreationResult(AIFrameCreation):
             crop_inertia=creation.crop_inertia,
             similarity_minimum=creation.similarity_minimum,
             do_croppan=creation.do_croppan,
+            tiling_cols=creation.tiling_cols,
+            tiling_rows=creation.tiling_rows,
+            tiling_overlap=creation.tiling_overlap,
             frame_count=frame_count,
         )
 
@@ -119,6 +126,15 @@ def create_frames(
 
     if frame_creation.similarity_minimum is not None:
         handlers.append(FilterSSIM(similarity_minimum=frame_creation.similarity_minimum))
+
+    if frame_creation.tiling_cols is not None and frame_creation.tiling_rows is not None:
+        handlers.append(
+            FrameTiler(
+                cols=frame_creation.tiling_cols,
+                rows=frame_creation.tiling_rows,
+                overlap=frame_creation.tiling_overlap or 0.0,
+            )
+        )
 
     handlers.append(FrameImageWriter(frame_creation.tmpdir))
 

--- a/src/wildcamtools/lib/frames.py
+++ b/src/wildcamtools/lib/frames.py
@@ -108,7 +108,29 @@ class FrameImageWriter(FrameHandler):
         super().__init__()
 
     def handle(self, frame: Frame) -> Frame:
+        # write a whole frame image
         if frame.filter_keep:
+            if frame.tiles is not None and frame.tiling_rows is not None and frame.tiling_cols is not None:
+                for row in range(frame.tiling_rows):
+                    for col in range(frame.tiling_cols):
+                        tile = frame.get_tile(col, row)
+                        if tile is not None:
+                            filename = self.output_dir / f"frame_{frame.frame_no:05d}_tile_{row}_{col}.jpg"
+                            cv2.imwrite(str(filename), tile)
+                            logger.debug(
+                                "Writing tile %d,%d (%dx%d) -> %s",
+                                row,
+                                col,
+                                tile.shape[0],
+                                tile.shape[1],
+                                filename,
+                            )
+                logger.info(
+                    "Wrote %d tiles for frame %s",
+                    len(frame.tiles),
+                    frame.frame_no,
+                )
+            # write a whole frame image
             filename = self.output_dir / f"frame_{frame.frame_no:05d}.jpg"
             cv2.imwrite(str(filename), frame.output)
             logger.debug("Writing %s -> %s", frame.frame_no, filename)
@@ -322,4 +344,85 @@ class CropPanHandler(FrameHandler):
         frame.crop = crop
         frame.crop_bbox = self.window
         frame.motion_proportion = frame_mask.motion_proportion
+        return frame
+
+
+class FrameTiler(FrameHandler):
+    """Splits frames into a grid of tiles for parallel motion detection.
+
+    When image dimensions don't divide evenly, extra pixels are distributed
+    to edge tiles (right and bottom edges are larger).
+    """
+
+    cols: int
+    rows: int
+    overlap: float
+
+    def __init__(self, cols: int = 2, rows: int = 2, overlap: float = 0.0) -> None:
+        if cols < 1:
+            raise ValueError(f"cols must be at least 1, got {cols}")
+        if rows < 1:
+            raise ValueError(f"rows must be at least 1, got {rows}")
+        if overlap < 0.0 or overlap >= 1.0:
+            raise ValueError(f"overlap must be between 0.0 and 1.0, got {overlap}")
+        self.cols = cols
+        self.rows = rows
+        self.overlap = overlap
+        super().__init__()
+
+    def handle(self, frame: Frame) -> Frame:
+        img = frame.output
+        img_h, img_w = img.shape[:2]
+
+        if self.overlap > 0:
+            tile_w = img_w / (1 + (self.cols - 1) * (1 - self.overlap))
+            tile_h = img_h / (1 + (self.rows - 1) * (1 - self.overlap))
+        else:
+            tile_w = img_w / self.cols
+            tile_h = img_h / self.rows
+
+        tile_w_int = int(tile_w)
+        tile_h_int = int(tile_h)
+
+        logger.info(
+            "Tiling frame %s: %dx%d -> %dx%d tiles (%d cols x %d rows, overlap %.2f%%)",
+            frame.frame_no,
+            img_w,
+            img_h,
+            tile_w_int,
+            tile_h_int,
+            self.cols,
+            self.rows,
+            self.overlap * 100,
+        )
+
+        tiles: list[cv2.typing.MatLike] = []
+        for row in range(self.rows):
+            for col in range(self.cols):
+                x_start = int(col * tile_w * (1 - self.overlap))
+                y_start = int(row * tile_h * (1 - self.overlap))
+
+                if col == self.cols - 1:
+                    x_start = img_w - tile_w_int
+                if row == self.rows - 1:
+                    y_start = img_h - tile_h_int
+
+                x_end = x_start + tile_w_int
+                y_end = y_start + tile_h_int
+
+                tile = img[y_start:y_end, x_start:x_end]
+                tiles.append(tile)
+                logger.debug(
+                    "Tile (%d,%d): %dx%d pixels",
+                    row,
+                    col,
+                    tile.shape[1],
+                    tile.shape[0],
+                )
+
+        frame.tiles = tiles
+        frame.tiling_cols = self.cols
+        frame.tiling_rows = self.rows
+        frame.tiling_width = tile_w_int
+        frame.tiling_height = tile_h_int
         return frame

--- a/tests/lib/test_frame.py
+++ b/tests/lib/test_frame.py
@@ -311,6 +311,34 @@ class TestHandlerChainIntegration:
         assert written_image.shape[0] == 50
         assert written_image.shape[1] == 100
 
+    def test_frame_image_writer_writes_tiles(self, tmp_path):
+        from wildcamtools.lib.frames import FrameImageWriter, FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        frame = tiler.handle(frame)
+
+        writer = FrameImageWriter(tmp_path)
+        result = writer.handle(frame)
+
+        assert result.filter_keep is True
+        assert (tmp_path / "frame_00001_tile_0_0.jpg").exists()
+        assert (tmp_path / "frame_00001_tile_0_1.jpg").exists()
+        assert (tmp_path / "frame_00001_tile_1_0.jpg").exists()
+        assert (tmp_path / "frame_00001_tile_1_1.jpg").exists()
+
+        import cv2
+
+        for row in range(2):
+            for col in range(2):
+                tile_file = tmp_path / f"frame_00001_tile_{row}_{col}.jpg"
+                tile_image = cv2.imread(str(tile_file))
+                assert tile_image is not None
+                assert tile_image.shape[0] == 50
+                assert tile_image.shape[1] == 100
+
     def test_rescaler_uses_output_property(self):
         from wildcamtools.lib.frames import Rescaler
         from wildcamtools.lib.stats import Colourspace, VideoStats
@@ -356,3 +384,279 @@ class TestHandlerChainIntegration:
         assert frame.output is rescale
         assert frame.width_rescaled == 50
         assert frame.height_rescaled == 25
+
+
+class TestFrameTiling:
+    def test_frame_tiling_fields_default_to_none(self):
+        raw = np.zeros((100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        assert frame.tiles is None
+        assert frame.tiling_cols is None
+        assert frame.tiling_rows is None
+        assert frame.tiling_width is None
+        assert frame.tiling_height is None
+
+    def test_get_tile_returns_none_when_no_tiles(self):
+        raw = np.zeros((100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        assert frame.get_tile(0, 0) is None
+
+    def test_get_tile_returns_none_for_invalid_coordinates(self):
+        raw = np.zeros((100, 200, 3), dtype=np.uint8)
+        frame = Frame(
+            raw=raw, frame_no=1, tiles=[raw], tiling_cols=1, tiling_rows=1, tiling_width=200, tiling_height=100
+        )
+
+        assert frame.get_tile(-1, 0) is None
+        assert frame.get_tile(0, -1) is None
+        assert frame.get_tile(1, 0) is None
+        assert frame.get_tile(0, 1) is None
+        assert frame.get_tile(5, 5) is None
+
+    def test_get_tile_returns_correct_tile(self):
+        raw = np.zeros((100, 200, 3), dtype=np.uint8)
+        tile1 = np.ones((50, 100, 3), dtype=np.uint8)
+        tile2 = np.ones((50, 100, 3), dtype=np.uint8) * 2
+        tiles = [tile1, tile2]
+
+        frame = Frame(
+            raw=raw, frame_no=1, tiles=tiles, tiling_cols=2, tiling_rows=1, tiling_width=100, tiling_height=50
+        )
+
+        assert np.array_equal(frame.get_tile(0, 0), tile1)
+        assert np.array_equal(frame.get_tile(1, 0), tile2)
+
+
+class TestFrameTiler:
+    def test_frame_tiler_creation(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        tiler = FrameTiler(cols=3, rows=2)
+        assert tiler.cols == 3
+        assert tiler.rows == 2
+
+    def test_frame_tiler_default_values(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        tiler = FrameTiler()
+        assert tiler.cols == 2
+        assert tiler.rows == 2
+
+    def test_frame_tiler_invalid_cols(self):
+        import pytest
+
+        from wildcamtools.lib.frames import FrameTiler
+
+        with pytest.raises(ValueError, match="cols must be at least 1"):
+            FrameTiler(cols=0)
+
+        with pytest.raises(ValueError, match="cols must be at least 1"):
+            FrameTiler(cols=-1)
+
+    def test_frame_tiler_invalid_rows(self):
+        import pytest
+
+        from wildcamtools.lib.frames import FrameTiler
+
+        with pytest.raises(ValueError, match="rows must be at least 1"):
+            FrameTiler(rows=0)
+
+        with pytest.raises(ValueError, match="rows must be at least 1"):
+            FrameTiler(rows=-1)
+
+    def test_frame_tiler_splits_frame_into_tiles(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 4
+        assert result.tiling_cols == 2
+        assert result.tiling_rows == 2
+        assert result.tiling_width == 100
+        assert result.tiling_height == 50
+
+    def test_frame_tiler_tiles_cover_image(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        for tile in result.tiles:
+            assert tile.shape[0] == 50
+            assert tile.shape[1] == 100
+            assert tile.shape[2] == 3
+
+    def test_frame_tiler_get_tile_access(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.get_tile(0, 0) is not None
+        assert result.get_tile(1, 0) is not None
+        assert result.get_tile(0, 1) is not None
+        assert result.get_tile(1, 1) is not None
+
+    def test_frame_tiler_single_tile(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=1, rows=1)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 1
+        assert result.tiling_cols == 1
+        assert result.tiling_rows == 1
+        assert result.tiling_width == 200
+        assert result.tiling_height == 100
+        assert np.array_equal(result.tiles[0], raw)
+
+    def test_frame_tiler_uses_output_property(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.zeros((100, 200, 3), dtype=np.uint8)
+        crop = np.random.randint(0, 255, (50, 100, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1, crop=crop)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 4
+        for tile in result.tiles:
+            assert tile.shape[2] == 3
+
+    def test_frame_tiler_non_divisible_dimensions(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (101, 201, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 4
+        assert all(tile.shape == result.tiles[0].shape for tile in result.tiles)
+        assert result.tiles[0].shape == (50, 100, 3)
+        assert result.tiling_width == 100
+        assert result.tiling_height == 50
+
+    def test_frame_tiler_covers_entire_image(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=3, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 6
+        assert all(tile.shape == result.tiles[0].shape for tile in result.tiles)
+
+        tile_h, tile_w = result.tiles[0].shape[:2]
+        step_y = int(tile_h * (1 - 0))
+        step_x = int(tile_w * (1 - 0))
+
+        last_tile_start_y = raw.shape[0] - tile_h
+        last_tile_start_x = raw.shape[1] - tile_w
+        assert last_tile_start_y >= step_y
+        assert last_tile_start_x >= step_x * 2
+        assert last_tile_start_y + tile_h == raw.shape[0]
+        assert last_tile_start_x + tile_w == raw.shape[1]
+
+    def test_frame_tiler_asymmetric_grid(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=3, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 6
+        assert result.tiling_cols == 3
+        assert result.tiling_rows == 2
+        assert result.tiling_width == 66
+        assert result.tiling_height == 50
+
+    def test_frame_tiler_overlap_default(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 4
+        assert result.tiles[0].shape == (50, 100, 3)
+
+    def test_frame_tiler_overlap_fifty_percent(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=2, rows=2, overlap=0.5)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 4
+        assert all(tile.shape == result.tiles[0].shape for tile in result.tiles)
+        assert result.tiles[0].shape[0] > 50
+        assert result.tiles[0].shape[1] > 100
+
+    def test_frame_tiler_overlap_coverage(self):
+        from wildcamtools.lib.frames import FrameTiler
+
+        raw = np.random.randint(0, 255, (100, 200, 3), dtype=np.uint8)
+        frame = Frame(raw=raw, frame_no=1)
+
+        tiler = FrameTiler(cols=3, rows=2, overlap=0.5)
+        result = tiler.handle(frame)
+
+        assert result.tiles is not None
+        assert len(result.tiles) == 6
+        assert all(tile.shape == result.tiles[0].shape for tile in result.tiles)
+
+        tile_h, tile_w = result.tiles[0].shape[:2]
+        last_tile_start_y = raw.shape[0] - tile_h
+        last_tile_start_x = raw.shape[1] - tile_w
+
+        assert last_tile_start_y + tile_h == raw.shape[0]
+        assert last_tile_start_x + tile_w == raw.shape[1]
+
+    def test_frame_tiler_overlap_invalid(self):
+        import pytest
+
+        from wildcamtools.lib.frames import FrameTiler
+
+        with pytest.raises(ValueError, match=r"overlap must be between 0\.0 and 1\.0"):
+            FrameTiler(cols=2, rows=2, overlap=-0.1)
+
+        with pytest.raises(ValueError, match=r"overlap must be between 0\.0 and 1\.0"):
+            FrameTiler(cols=2, rows=2, overlap=1.0)
+
+        with pytest.raises(ValueError, match=r"overlap must be between 0\.0 and 1\.0"):
+            FrameTiler(cols=2, rows=2, overlap=1.5)


### PR DESCRIPTION
## Summary

Adds optional frame tiling functionality to split video frames into a grid of overlapping tiles for more granular AI analysis.

## Changes

### Core Implementation
- **FrameTiler class** (`src/wildcamtools/lib/frames.py`): Splits frames into configurable grid with overlap support
  - Uniform tile sizes with full image coverage guaranteed
  - Overlap proportion configurable (0.0-1.0, exclusive)
  - Float arithmetic for precise tile sizing
  - Comprehensive logging of tile dimensions

### Data Model
- **Frame class** (`src/wildcamtools/lib/__init__.py`): Added tiling fields
  - `tiles`: List of tile images
  - `tiling_cols`, `tiling_rows`: Grid dimensions
  - `tiling_width`, `tiling_height`: Base tile size
  - `get_tile(x, y)`: Method for coordinate-based tile access

### AI Integration
- **AIFrameCreation** (`src/wildcamtools/lib/ai/evaluate.py`): Added tiling configuration
  - `tiling_cols`, `tiling_rows`, `tiling_overlap` fields
  - FrameTiler added to processing pipeline after similarity filtering
  - Results include tiling parameters in JSONL output

### CLI
- **evaluate command** (`src/wildcamtools/cli/ai.py`): New options
  - `--tiling-cols`: Number of horizontal tiles
  - `--tiling-rows`: Number of vertical tiles  
  - `--tiling-overlap`: Overlap proportion between tiles
  - Validation with informative error messages
  - Implicit tiling: single dimension defaults to 1

### Frame Output
- **FrameImageWriter** (`src/wildcamtools/lib/frames.py`): Tile file writing
  - Writes `frame_XXXXX_tile_row_col.jpg` when tiling enabled
  - Falls back to single frame writing otherwise
  - Logs tile dimensions and counts

## Testing

- 53 tests passing (16 new tiling tests)
- Coverage includes:
  - Basic tiling (no overlap)
  - Overlap functionality (50% overlap verified)
  - Non-divisible dimensions
  - Coverage verification (no gaps with 3+ columns)
  - Invalid parameter validation

## Example Usage

```bash
# 2x2 grid with 50% overlap
uv run wildcamtools ai evaluate labels.json --model qwen3.5:cloud \
  --tiling-cols 2 --tiling-rows 2 --tiling-overlap 0.5

# 3x3 grid without overlap
uv run wildcamtools ai evaluate labels.json --model qwen3.5:cloud \
  --tiling-cols 3 --tiling-rows 3
```

## Backward Compatibility

- All tiling parameters default to `None` (disabled)
- Existing code continues to work unchanged
- FrameImageWriter maintains single-frame behavior when no tiles