### PR TITLE
Create pipeline evaluation summary json

### DIFF
--- a/src/wildcamtools/cli/ai.py
+++ b/src/wildcamtools/cli/ai.py
@@ -95,15 +95,15 @@ def run_evaluate(
             "-o",
             "--output",
             metavar="OUTPUT",
-            help="Optional output JSONL file for results (defaults to ./pipeline_evaluation_result.jsonl)",
+            help="Optional output JSON file for results)",
         ),
     ] = None,
 ) -> None:
     """Evaluate AiPipeline against labeled videos using a JSON configuration file.
 
     Runs the configured pipeline on each video in the labels file and compares
-    results against ground truth labels. Outputs summary statistics and optional
-    detailed results to JSONL file.
+    results against ground truth labels. Outputs summary statistics and detailed
+    results as a single JSON object.
 
     By default, uses exact string matching for comparison. Provide --label-comparison-config
     to enable semantic matching using an LLM.
@@ -120,8 +120,14 @@ def run_evaluate(
         labels_path=labels,
         video_dir=video_dir,
         max_workers=max_workers,
-        result_jsonl_path=output,
         comparison_config_path=comparison_config_path,
     )
+
+    json_output = summary.model_dump_json(indent=2)
+
+    if output:
+        output.write_text(json_output)
+    else:
+        typer.secho(json_output)
 
     summary.print_summary()

--- a/src/wildcamtools/lib/ai/pipeline_evaluation.py
+++ b/src/wildcamtools/lib/ai/pipeline_evaluation.py
@@ -1,8 +1,9 @@
-import json
 import logging
 import multiprocessing
-from dataclasses import dataclass
+import time
 from pathlib import Path
+
+from pydantic import BaseModel, Field
 
 from wildcamtools.lib.ai.label_comparison_config import LabelComparisonConfig
 from wildcamtools.lib.ai.pipeline_config import AiPipelineConfig
@@ -12,22 +13,22 @@ from wildcamtools.lib.labels import load_labels
 logger = logging.getLogger(__name__)
 
 
-@dataclass(kw_only=True)
-class PipelineEvaluationResult:
+class PipelineEvaluationResult(BaseModel):
     filename: str
     correct: bool
     raw_result: str
     label: str
     error: str | None = None
     comparison_method: str = "exact"
+    processing_time_seconds: float = 0.0
 
 
-@dataclass(kw_only=True)
-class PipelineEvaluationSummary:
-    results: list[PipelineEvaluationResult]
-    correct_count: int
-    total_count: int
-    error_count: int
+class PipelineEvaluationSummary(BaseModel):
+    results: list[PipelineEvaluationResult] = Field(default_factory=list)
+    correct_count: int = 0
+    total_count: int = 0
+    error_count: int = 0
+    average_processing_time_seconds: float = 0.0
 
     @property
     def accuracy(self) -> float:
@@ -38,12 +39,21 @@ class PipelineEvaluationSummary:
             return 0.0
         return self.correct_count / valid_count
 
+    @property
+    def success_rate(self) -> float:
+        return self.accuracy
+
+    @property
+    def failure_count(self) -> int:
+        return self.total_count - self.correct_count
+
     def print_summary(self) -> None:
         logger.info("Evaluation Summary:")
         logger.info("  Total: %d", self.total_count)
         logger.info("  Correct: %d", self.correct_count)
         logger.info("  Errors: %d", self.error_count)
         logger.info("  Accuracy: %.4f", self.accuracy)
+        logger.info("  Average processing time: %.2f seconds", self.average_processing_time_seconds)
 
 
 def _evaluate_video_worker(
@@ -54,9 +64,13 @@ def _evaluate_video_worker(
 ) -> PipelineEvaluationResult:
     video_path = Path(video_path_str)
     try:
+        start_time = time.time()
         pipeline = pipeline_config.create_pipeline()
         result = pipeline.run(video_path)
+        end_time = time.time()
+        processing_time = end_time - start_time
 
+        # TODO this more cleanly - base class with a abstract method?
         if isinstance(result, SpeciesResult) or hasattr(result, "species_name"):
             raw_result = result.species_name
         elif hasattr(result, "message"):
@@ -82,6 +96,7 @@ def _evaluate_video_worker(
             label=ground_truth_label,
             error=None,
             comparison_method=comparator.method_name,
+            processing_time_seconds=processing_time,
         )
     except Exception:
         logger.exception("Worker failed for video %s", video_path.name)
@@ -120,7 +135,6 @@ def _run_worker_pool(
             if not video_path.exists():
                 logger.warning("Video not found: %s", filename)
                 continue
-            # TODO use a Pydantic model to a dictionary as kwargs
             future = pool.apply_async(
                 _evaluate_video_worker,
                 args=(str(video_path), label, pipeline_config, comparison_config),
@@ -141,25 +155,11 @@ def _run_worker_pool(
                         label="unknown",
                         error=str(e),
                         comparison_method="exact",
+                        processing_time_seconds=0.0,
                     )
                 )
 
     return results
-
-
-def _write_results(results: list[PipelineEvaluationResult], result_jsonl_path: Path) -> None:
-    result_jsonl_path.unlink(missing_ok=True)
-    with open(result_jsonl_path, "w") as result_file:
-        for result in results:
-            result_dict = {
-                "filename": result.filename,
-                "correct": result.correct,
-                "raw_result": result.raw_result,
-                "label": result.label,
-                "error": result.error,
-                "comparison_method": result.comparison_method,
-            }
-            result_file.write(json.dumps(result_dict) + "\n")
 
 
 def evaluate_ai_pipeline(
@@ -167,7 +167,6 @@ def evaluate_ai_pipeline(
     labels_path: Path,
     video_dir: Path | None = None,
     max_workers: int | None = None,
-    result_jsonl_path: Path | None = None,
     comparison_config_path: Path | None = None,
 ) -> PipelineEvaluationSummary:
     """Evaluate AiPipeline against labeled videos.
@@ -177,7 +176,6 @@ def evaluate_ai_pipeline(
         labels_path: Path to JSONL file with video labels.
         video_dir: Directory containing video files. Defaults to parent of labels_path.
         max_workers: Maximum number of worker processes. Defaults to CPU count.
-        result_jsonl_path: Path to write results. Defaults to current directory.
         comparison_config_path: Path to JSON config for label comparison. Defaults to None for exact matching.
 
     Returns:
@@ -187,7 +185,6 @@ def evaluate_ai_pipeline(
         FileNotFoundError: If config_path, labels_path, or comparison_config_path doesn't exist.
         ValueError: If config_path, labels_path, or comparison_config_path is not a file.
     """
-    # TODO refactor these into more modular and reusable convenience functions (e.g validate_file, validate_dir)
     _validate_paths(config_path, labels_path, video_dir)
     if comparison_config_path is not None:
         if not comparison_config_path.exists():
@@ -199,9 +196,6 @@ def evaluate_ai_pipeline(
     if video_dir is None:
         video_dir = labels_path.parent
 
-    if result_jsonl_path is None:
-        result_jsonl_path = Path.cwd() / "pipeline_evaluation_result.jsonl"
-
     pipeline_config = AiPipelineConfig.from_json(config_path)
     comparison_config = (
         LabelComparisonConfig.from_json(comparison_config_path)
@@ -210,15 +204,17 @@ def evaluate_ai_pipeline(
     )
 
     results = _run_worker_pool(labelled_data, video_dir, pipeline_config, max_workers, comparison_config)
-    _write_results(results, result_jsonl_path)
 
     correct_count = sum(1 for r in results if r.correct and r.error is None)
     error_count = sum(1 for r in results if r.error is not None)
     total_count = len(results)
+    total_processing_time = sum(r.processing_time_seconds for r in results)
+    average_processing_time = total_processing_time / total_count if total_count > 0 else 0.0
 
     return PipelineEvaluationSummary(
         results=results,
         correct_count=correct_count,
         total_count=total_count,
         error_count=error_count,
+        average_processing_time_seconds=average_processing_time,
     )

--- a/tests/cli/test_ai.py
+++ b/tests/cli/test_ai.py
@@ -401,17 +401,19 @@ class TestRunEvaluateCommand:
                     raw_result="otter",
                     label="otter",
                     comparison_method="exact",
+                    processing_time_seconds=1.0,
                 ),
             ],
             correct_count=1,
             total_count=1,
             error_count=0,
+            average_processing_time_seconds=1.0,
         )
 
         with patch("wildcamtools.cli.ai.evaluate_ai_pipeline") as mock_eval:
             mock_eval.return_value = mock_summary
 
-            output_file = tmp_path / "results.jsonl"
+            output_file = tmp_path / "results.json"
             result = runner.invoke(
                 ai_app,
                 [
@@ -431,9 +433,13 @@ class TestRunEvaluateCommand:
                 labels_path=sample_labels_file,
                 video_dir=None,
                 max_workers=2,
-                result_jsonl_path=output_file,
                 comparison_config_path=sample_comparison_config_file,
             )
+            assert output_file.exists()
+            json_content = json.loads(output_file.read_text())
+            assert "results" in json_content
+            assert "correct_count" in json_content
+            assert "average_processing_time_seconds" in json_content
 
     def test_run_evaluate_with_label_comparison_config(
         self,
@@ -450,11 +456,13 @@ class TestRunEvaluateCommand:
                     raw_result="domestic cat",
                     label="cat",
                     comparison_method="llm",
+                    processing_time_seconds=1.0,
                 ),
             ],
             correct_count=1,
             total_count=1,
             error_count=0,
+            average_processing_time_seconds=1.0,
         )
 
         with patch("wildcamtools.cli.ai.evaluate_ai_pipeline") as mock_eval:
@@ -473,3 +481,91 @@ class TestRunEvaluateCommand:
             mock_eval.assert_called_once()
             call_kwargs = mock_eval.call_args.kwargs
             assert call_kwargs["comparison_config_path"] == sample_comparison_config_file
+
+    def test_run_evaluate_json_output_to_stdout(
+        self,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
+    ) -> None:
+        mock_summary = PipelineEvaluationSummary(
+            results=[
+                PipelineEvaluationResult(
+                    filename="test.mp4",
+                    correct=True,
+                    raw_result="otter",
+                    label="otter",
+                    comparison_method="exact",
+                    processing_time_seconds=1.5,
+                ),
+            ],
+            correct_count=1,
+            total_count=1,
+            error_count=0,
+            average_processing_time_seconds=1.5,
+        )
+
+        with patch("wildcamtools.cli.ai.evaluate_ai_pipeline") as mock_eval:
+            mock_eval.return_value = mock_summary
+
+            result = runner.invoke(
+                ai_app,
+                [
+                    "run-evaluate",
+                    str(sample_config_file),
+                    str(sample_comparison_config_file),
+                    str(sample_labels_file),
+                ],
+            )
+            assert result.exit_code == 0
+            json_output = json.loads(result.stdout)
+            assert "results" in json_output
+            assert json_output["correct_count"] == 1
+            assert json_output["average_processing_time_seconds"] == 1.5
+
+    def test_run_evaluate_json_output_to_file(
+        self,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
+        tmp_path: Path,
+    ) -> None:
+        mock_summary = PipelineEvaluationSummary(
+            results=[
+                PipelineEvaluationResult(
+                    filename="test.mp4",
+                    correct=True,
+                    raw_result="otter",
+                    label="otter",
+                    comparison_method="exact",
+                    processing_time_seconds=2.0,
+                ),
+            ],
+            correct_count=1,
+            total_count=1,
+            error_count=0,
+            average_processing_time_seconds=2.0,
+        )
+
+        with patch("wildcamtools.cli.ai.evaluate_ai_pipeline") as mock_eval:
+            mock_eval.return_value = mock_summary
+
+            output_file = tmp_path / "evaluation_result.json"
+            result = runner.invoke(
+                ai_app,
+                [
+                    "run-evaluate",
+                    str(sample_config_file),
+                    str(sample_comparison_config_file),
+                    str(sample_labels_file),
+                    "-o",
+                    str(output_file),
+                ],
+            )
+            assert result.exit_code == 0
+            assert output_file.exists()
+            json_content = json.loads(output_file.read_text())
+            assert json_content["correct_count"] == 1
+            assert json_content["average_processing_time_seconds"] == 2.0
+            assert len(json_content["results"]) == 1
+            assert json_content["results"][0]["processing_time_seconds"] == 2.0

--- a/tests/lib/ai/test_pipeline_evaluation.py
+++ b/tests/lib/ai/test_pipeline_evaluation.py
@@ -5,13 +5,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from wildcamtools.lib.ai import (
-    AiPipelineConfig,
     PipelineEvaluationResult,
     PipelineEvaluationSummary,
     SpeciesResult,
     StringResponse,
 )
 from wildcamtools.lib.ai.label_comparison_config import LabelComparisonConfig
+from wildcamtools.lib.ai.pipeline_config import AiPipelineConfig
 from wildcamtools.lib.ai.pipeline_evaluation import (
     _evaluate_video_worker,
     evaluate_ai_pipeline,
@@ -32,6 +32,7 @@ class TestPipelineEvaluationResult:
         assert result.label == "otter"
         assert result.error is None
         assert result.comparison_method == "exact"
+        assert result.processing_time_seconds == 0.0
 
     def test_result_with_error(self) -> None:
         result = PipelineEvaluationResult(
@@ -43,6 +44,7 @@ class TestPipelineEvaluationResult:
         )
         assert result.error == "Connection timeout"
         assert result.correct is False
+        assert result.processing_time_seconds == 0.0
 
     def test_result_with_comparison_method(self) -> None:
         result = PipelineEvaluationResult(
@@ -53,6 +55,16 @@ class TestPipelineEvaluationResult:
             comparison_method="llm",
         )
         assert result.comparison_method == "llm"
+
+    def test_result_with_processing_time(self) -> None:
+        result = PipelineEvaluationResult(
+            filename="test.mp4",
+            correct=True,
+            raw_result="otter",
+            label="otter",
+            processing_time_seconds=1.5,
+        )
+        assert result.processing_time_seconds == 1.5
 
 
 class TestPipelineEvaluationSummary:
@@ -70,6 +82,7 @@ class TestPipelineEvaluationSummary:
         assert summary.correct_count == 1
         assert summary.total_count == 2
         assert summary.error_count == 0
+        assert summary.average_processing_time_seconds == 0.0
 
     def test_accuracy_calculation(self) -> None:
         results = [
@@ -135,6 +148,72 @@ class TestPipelineEvaluationSummary:
         )
         assert summary.accuracy == pytest.approx(expected)
 
+    def test_success_rate_property(self) -> None:
+        results = [
+            PipelineEvaluationResult(filename="test1.mp4", correct=True, raw_result="otter", label="otter"),
+            PipelineEvaluationResult(filename="test2.mp4", correct=True, raw_result="cat", label="cat"),
+        ]
+        summary = PipelineEvaluationSummary(
+            results=results,
+            correct_count=2,
+            total_count=3,
+            error_count=0,
+        )
+        assert summary.success_rate == summary.accuracy
+
+    def test_failure_count_property(self) -> None:
+        results = [
+            PipelineEvaluationResult(filename="test1.mp4", correct=True, raw_result="otter", label="otter"),
+            PipelineEvaluationResult(filename="test2.mp4", correct=False, raw_result="cat", label="cat"),
+        ]
+        summary = PipelineEvaluationSummary(
+            results=results,
+            correct_count=1,
+            total_count=3,
+            error_count=0,
+        )
+        assert summary.failure_count == 2
+
+    def test_average_processing_time(self) -> None:
+        results = [
+            PipelineEvaluationResult(
+                filename="test1.mp4", correct=True, raw_result="otter", label="otter", processing_time_seconds=1.0
+            ),
+            PipelineEvaluationResult(
+                filename="test2.mp4", correct=True, raw_result="cat", label="cat", processing_time_seconds=2.0
+            ),
+            PipelineEvaluationResult(
+                filename="test3.mp4", correct=True, raw_result="dog", label="dog", processing_time_seconds=3.0
+            ),
+        ]
+        summary = PipelineEvaluationSummary(
+            results=results,
+            correct_count=3,
+            total_count=3,
+            error_count=0,
+            average_processing_time_seconds=2.0,
+        )
+        assert summary.average_processing_time_seconds == 2.0
+
+    def test_json_serialization(self) -> None:
+        results = [
+            PipelineEvaluationResult(
+                filename="test1.mp4", correct=True, raw_result="otter", label="otter", processing_time_seconds=1.5
+            ),
+        ]
+        summary = PipelineEvaluationSummary(
+            results=results,
+            correct_count=1,
+            total_count=1,
+            error_count=0,
+            average_processing_time_seconds=1.5,
+        )
+        json_str = summary.model_dump_json(indent=2)
+        assert "test1.mp4" in json_str
+        assert "correct" in json_str
+        assert "processing_time_seconds" in json_str
+        assert "average_processing_time_seconds" in json_str
+
 
 class TestEvaluateVideoWorker:
     def test_worker_with_mocked_pipeline_in_worker(
@@ -142,144 +221,110 @@ class TestEvaluateVideoWorker:
         data_directory: Path,
     ) -> None:
         mock_result = SpeciesResult(species_name="otter")
-        with (
-            patch("wildcamtools.lib.ai.pipeline_evaluation.AiPipelineConfig") as mock_config_class,
-            patch("wildcamtools.lib.ai.pipeline_evaluation.SpeciesResult", new=SpeciesResult),
-            patch("wildcamtools.lib.ai.pipeline_evaluation.LabelComparisonConfig") as mock_comparison_class,
-        ):
-            mock_config = MagicMock()
-            mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = mock_result
-            mock_config.create_pipeline.return_value = mock_pipeline
-            mock_config_class.model_validate.return_value = mock_config
+        mock_config = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.run.return_value = mock_result
+        mock_config.create_pipeline.return_value = mock_pipeline
 
-            mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = True
-            mock_comparator.method_name = "exact"
-            mock_comparison_config = MagicMock()
-            mock_comparison_config.create_comparator.return_value = mock_comparator
-            mock_comparison_class.model_validate.return_value = mock_comparison_config
+        mock_comparator = MagicMock()
+        mock_comparator.compare.return_value = True
+        mock_comparator.method_name = "exact"
+        mock_comparison_config = MagicMock()
+        mock_comparison_config.create_comparator.return_value = mock_comparator
 
-            video_path = data_directory / "test.mp4"
-            result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        video_path = data_directory / "test.mp4"
+        result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
 
-            assert result.filename == "test.mp4"
-            assert result.correct is True
-            assert result.raw_result == "otter"
-            assert result.label == "otter"
-            assert result.error is None
+        assert result.filename == "test.mp4"
+        assert result.correct is True
+        assert result.raw_result == "otter"
+        assert result.label == "otter"
+        assert result.error is None
+        assert result.processing_time_seconds > 0.0
 
     def test_worker_incorrect_result_with_mock(
         self,
         data_directory: Path,
     ) -> None:
         mock_result = SpeciesResult(species_name="cat")
-        with (
-            patch("wildcamtools.lib.ai.pipeline_evaluation.AiPipelineConfig") as mock_config_class,
-            patch("wildcamtools.lib.ai.pipeline_evaluation.SpeciesResult", new=SpeciesResult),
-            patch("wildcamtools.lib.ai.pipeline_evaluation.LabelComparisonConfig") as mock_comparison_class,
-        ):
-            mock_config = MagicMock()
-            mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = mock_result
-            mock_config.create_pipeline.return_value = mock_pipeline
-            mock_config_class.model_validate.return_value = mock_config
+        mock_config = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.run.return_value = mock_result
+        mock_config.create_pipeline.return_value = mock_pipeline
 
-            mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = False
-            mock_comparator.method_name = "exact"
-            mock_comparison_config = MagicMock()
-            mock_comparison_config.create_comparator.return_value = mock_comparator
-            mock_comparison_class.model_validate.return_value = mock_comparison_config
+        mock_comparator = MagicMock()
+        mock_comparator.compare.return_value = False
+        mock_comparator.method_name = "exact"
+        mock_comparison_config = MagicMock()
+        mock_comparison_config.create_comparator.return_value = mock_comparator
 
-            video_path = data_directory / "test.mp4"
-            result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        video_path = data_directory / "test.mp4"
+        result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
 
-            assert result.correct is False
-            assert result.raw_result == "cat"
-            assert result.label == "otter"
+        assert result.correct is False
+        assert result.raw_result == "cat"
+        assert result.label == "otter"
 
     def test_worker_case_insensitive_comparison_with_mock(
         self,
         data_directory: Path,
     ) -> None:
         mock_result = SpeciesResult(species_name="Otter")
-        with (
-            patch("wildcamtools.lib.ai.pipeline_evaluation.AiPipelineConfig") as mock_config_class,
-            patch("wildcamtools.lib.ai.pipeline_evaluation.SpeciesResult", new=SpeciesResult),
-            patch("wildcamtools.lib.ai.pipeline_evaluation.LabelComparisonConfig") as mock_comparison_class,
-        ):
-            mock_config = MagicMock()
-            mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = mock_result
-            mock_config.create_pipeline.return_value = mock_pipeline
-            mock_config_class.model_validate.return_value = mock_config
+        mock_config = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.run.return_value = mock_result
+        mock_config.create_pipeline.return_value = mock_pipeline
 
-            mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = True
-            mock_comparator.method_name = "exact"
-            mock_comparison_config = MagicMock()
-            mock_comparison_config.create_comparator.return_value = mock_comparator
-            mock_comparison_class.model_validate.return_value = mock_comparison_config
+        mock_comparator = MagicMock()
+        mock_comparator.compare.return_value = True
+        mock_comparator.method_name = "exact"
+        mock_comparison_config = MagicMock()
+        mock_comparison_config.create_comparator.return_value = mock_comparator
 
-            video_path = data_directory / "test.mp4"
-            result = _evaluate_video_worker(str(video_path), "OTTER", mock_config, mock_comparison_config)
+        video_path = data_directory / "test.mp4"
+        result = _evaluate_video_worker(str(video_path), "OTTER", mock_config, mock_comparison_config)
 
-            assert result.correct is True
+        assert result.correct is True
 
     def test_worker_error_handling_with_mock(
         self,
         data_directory: Path,
     ) -> None:
-        with (
-            patch("wildcamtools.lib.ai.pipeline_evaluation.AiPipelineConfig") as mock_config_class,
-            patch("wildcamtools.lib.ai.pipeline_evaluation.SpeciesResult", new=SpeciesResult),
-            patch("wildcamtools.lib.ai.pipeline_evaluation.LabelComparisonConfig") as mock_comparison_class,
-        ):
-            mock_config = MagicMock()
-            mock_pipeline = MagicMock()
-            mock_pipeline.run.side_effect = RuntimeError("LLM connection failed")
-            mock_config.create_pipeline.return_value = mock_pipeline
-            mock_config_class.model_validate.return_value = mock_config
+        mock_config = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.run.side_effect = RuntimeError("LLM connection failed")
+        mock_config.create_pipeline.return_value = mock_pipeline
 
-            mock_comparator = MagicMock()
-            mock_comparator.method_name = "exact"
-            mock_comparison_config = MagicMock()
-            mock_comparison_config.create_comparator.return_value = mock_comparator
-            mock_comparison_class.model_validate.return_value = mock_comparison_config
+        mock_comparator = MagicMock()
+        mock_comparator.method_name = "exact"
+        mock_comparison_config = MagicMock()
+        mock_comparison_config.create_comparator.return_value = mock_comparator
 
-            video_path = data_directory / "test.mp4"
-            with pytest.raises(RuntimeError, match="LLM connection failed"):
-                _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        video_path = data_directory / "test.mp4"
+        with pytest.raises(RuntimeError, match="LLM connection failed"):
+            _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
 
     def test_worker_with_string_response_result(
         self,
         data_directory: Path,
     ) -> None:
         mock_result = StringResponse(message="test response")
-        with (
-            patch("wildcamtools.lib.ai.pipeline_evaluation.AiPipelineConfig") as mock_config_class,
-            patch("wildcamtools.lib.ai.pipeline_evaluation.SpeciesResult", new=SpeciesResult),
-            patch("wildcamtools.lib.ai.pipeline_evaluation.LabelComparisonConfig") as mock_comparison_class,
-        ):
-            mock_config = MagicMock()
-            mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = mock_result
-            mock_config.create_pipeline.return_value = mock_pipeline
-            mock_config_class.model_validate.return_value = mock_config
+        mock_config = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_pipeline.run.return_value = mock_result
+        mock_config.create_pipeline.return_value = mock_pipeline
 
-            mock_comparator = MagicMock()
-            mock_comparator.compare.return_value = True
-            mock_comparator.method_name = "exact"
-            mock_comparison_config = MagicMock()
-            mock_comparison_config.create_comparator.return_value = mock_comparator
-            mock_comparison_class.model_validate.return_value = mock_comparison_config
+        mock_comparator = MagicMock()
+        mock_comparator.compare.return_value = True
+        mock_comparator.method_name = "exact"
+        mock_comparison_config = MagicMock()
+        mock_comparison_config.create_comparator.return_value = mock_comparator
 
-            video_path = data_directory / "test.mp4"
-            result = _evaluate_video_worker(str(video_path), "test response", mock_config, mock_comparison_config)
+        video_path = data_directory / "test.mp4"
+        result = _evaluate_video_worker(str(video_path), "test response", mock_config, mock_comparison_config)
 
-            assert result.raw_result == "test response"
-            assert result.correct is True
+        assert result.raw_result == "test response"
+        assert result.correct is True
 
 
 class TestEvaluateAiPipeline:
@@ -360,7 +405,7 @@ class TestEvaluateAiPipeline:
                 labels_path=tmp_path,
             )
 
-    def test_result_jsonl_created(
+    def test_evaluate_returns_summary(
         self,
         sample_config_file: Path,
         sample_comparison_config_file: Path,
@@ -368,8 +413,6 @@ class TestEvaluateAiPipeline:
         data_directory: Path,
         tmp_path: Path,
     ) -> None:
-        result_jsonl_path = tmp_path / "results.jsonl"
-
         with (
             patch.object(AiPipelineConfig, "model_validate") as mock_validate,
             patch.object(LabelComparisonConfig, "model_validate") as mock_comparison_validate,
@@ -395,6 +438,7 @@ class TestEvaluateAiPipeline:
                     raw_result="otter",
                     label="otter",
                     comparison_method="exact",
+                    processing_time_seconds=1.0,
                 ),
                 PipelineEvaluationResult(
                     filename="short.mp4",
@@ -402,29 +446,23 @@ class TestEvaluateAiPipeline:
                     raw_result="cat",
                     label="cat",
                     comparison_method="exact",
+                    processing_time_seconds=2.0,
                 ),
             ]
 
-            evaluate_ai_pipeline(
+            summary = evaluate_ai_pipeline(
                 config_path=sample_config_file,
                 comparison_config_path=sample_comparison_config_file,
                 labels_path=sample_labels_file,
                 video_dir=data_directory,
-                result_jsonl_path=result_jsonl_path,
                 max_workers=1,
             )
 
-            assert result_jsonl_path.exists()
-            lines = result_jsonl_path.read_text().strip().split("\n")
-            assert len(lines) == 2
-            for line in lines:
-                data = json.loads(line)
-                assert "filename" in data
-                assert "correct" in data
-                assert "raw_result" in data
-                assert "label" in data
-                assert "error" in data
-                assert "comparison_method" in data
+            assert summary.total_count == 2
+            assert summary.correct_count == 2
+            assert summary.error_count == 0
+            assert summary.average_processing_time_seconds == 1.5
+            assert len(summary.results) == 2
 
     def test_skips_missing_videos(
         self,
@@ -471,7 +509,7 @@ class TestEvaluateAiPipeline:
             assert summary.total_count == 0
             assert "Video not found: nonexistent.mp4" in caplog.text
 
-    def test_result_jsonl_overwritten_if_exists(
+    def test_evaluate_calculates_average_processing_time(
         self,
         sample_config_file: Path,
         sample_comparison_config_file: Path,
@@ -479,9 +517,6 @@ class TestEvaluateAiPipeline:
         data_directory: Path,
         tmp_path: Path,
     ) -> None:
-        result_jsonl_path = tmp_path / "results.jsonl"
-        result_jsonl_path.write_text('{"old": "data"}\n')
-
         with (
             patch.object(AiPipelineConfig, "model_validate") as mock_validate,
             patch.object(LabelComparisonConfig, "model_validate") as mock_comparison_validate,
@@ -507,20 +542,86 @@ class TestEvaluateAiPipeline:
                     raw_result="otter",
                     label="otter",
                     comparison_method="exact",
+                    processing_time_seconds=1.0,
+                ),
+                PipelineEvaluationResult(
+                    filename="short.mp4",
+                    correct=True,
+                    raw_result="cat",
+                    label="cat",
+                    comparison_method="exact",
+                    processing_time_seconds=3.0,
                 ),
             ]
 
-            evaluate_ai_pipeline(
+            summary = evaluate_ai_pipeline(
                 config_path=sample_config_file,
                 comparison_config_path=sample_comparison_config_file,
                 labels_path=sample_labels_file,
                 video_dir=data_directory,
-                result_jsonl_path=result_jsonl_path,
                 max_workers=1,
             )
 
-            content = result_jsonl_path.read_text()
-            assert '{"old": "data"}' not in content
+            assert summary.average_processing_time_seconds == 2.0
+
+    def test_evaluate_counts_errors(
+        self,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
+        data_directory: Path,
+        tmp_path: Path,
+    ) -> None:
+        with (
+            patch.object(AiPipelineConfig, "model_validate") as mock_validate,
+            patch.object(LabelComparisonConfig, "model_validate") as mock_comparison_validate,
+            patch("wildcamtools.lib.ai.pipeline_evaluation._run_worker_pool") as mock_pool,
+        ):
+            mock_config = MagicMock()
+            mock_pipeline = MagicMock()
+            mock_pipeline.run.return_value = SpeciesResult(species_name="otter")
+            mock_config.create_pipeline.return_value = mock_pipeline
+            mock_validate.return_value = mock_config
+
+            mock_comparator = MagicMock()
+            mock_comparator.compare.return_value = True
+            mock_comparator.method_name = "exact"
+            mock_comparison_config = MagicMock()
+            mock_comparison_config.create_comparator.return_value = mock_comparator
+            mock_comparison_validate.return_value = mock_comparison_config
+
+            mock_pool.return_value = [
+                PipelineEvaluationResult(
+                    filename="test.mp4",
+                    correct=True,
+                    raw_result="otter",
+                    label="otter",
+                    comparison_method="exact",
+                    processing_time_seconds=1.0,
+                ),
+                PipelineEvaluationResult(
+                    filename="short.mp4",
+                    correct=False,
+                    raw_result="",
+                    label="cat",
+                    error="LLM connection failed",
+                    comparison_method="exact",
+                    processing_time_seconds=0.0,
+                ),
+            ]
+
+            summary = evaluate_ai_pipeline(
+                config_path=sample_config_file,
+                comparison_config_path=sample_comparison_config_file,
+                labels_path=sample_labels_file,
+                video_dir=data_directory,
+                max_workers=1,
+            )
+
+            assert summary.error_count == 1
+            assert summary.correct_count == 1
+            assert summary.total_count == 2
+            assert summary.failure_count == 1
 
 
 class TestIntegration:
@@ -584,6 +685,7 @@ class TestIntegration:
                     raw_result="otter",
                     label="otter",
                     comparison_method="exact",
+                    processing_time_seconds=1.0,
                 ),
                 PipelineEvaluationResult(
                     filename="short.mp4",
@@ -591,6 +693,7 @@ class TestIntegration:
                     raw_result="cat",
                     label="cat",
                     comparison_method="exact",
+                    processing_time_seconds=2.0,
                 ),
             ]
 
@@ -605,3 +708,85 @@ class TestIntegration:
             assert summary.total_count == 2
             assert len(summary.results) == 2
             assert all(isinstance(r, PipelineEvaluationResult) for r in summary.results)
+            assert summary.average_processing_time_seconds == 1.5
+            assert summary.success_rate == summary.accuracy
+            assert summary.failure_count == 0
+
+    def test_end_to_end_json_serialization(
+        self,
+        tmp_path: Path,
+        data_directory: Path,
+    ) -> None:
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps({
+                "llm": {
+                    "model": "test-model",
+                    "backend": "ollama",
+                    "url": "http://localhost:8080/v1",
+                },
+                "query": {
+                    "prompt": "What species is in this image?",
+                },
+            })
+        )
+
+        comparison_config_file = tmp_path / "comparison_config.json"
+        comparison_config_file.write_text(
+            json.dumps({
+                "comparator_type": "exact",
+            })
+        )
+
+        labels_file = tmp_path / "labels.jsonl"
+        labels = [
+            {"video": "test.mp4", "label": "otter"},
+        ]
+        with open(labels_file, "w") as f:
+            for label in labels:
+                f.write(json.dumps(label) + "\n")
+
+        with (
+            patch.object(AiPipelineConfig, "model_validate") as mock_validate,
+            patch.object(LabelComparisonConfig, "model_validate") as mock_comparison_validate,
+            patch("wildcamtools.lib.ai.pipeline_evaluation._run_worker_pool") as mock_pool,
+        ):
+            mock_config = MagicMock()
+            mock_pipeline = MagicMock()
+            mock_pipeline.run.return_value = SpeciesResult(species_name="otter")
+            mock_config.create_pipeline.return_value = mock_pipeline
+            mock_validate.return_value = mock_config
+
+            mock_comparator = MagicMock()
+            mock_comparator.compare.return_value = True
+            mock_comparator.method_name = "exact"
+            mock_comparison_config = MagicMock()
+            mock_comparison_config.create_comparator.return_value = mock_comparator
+            mock_comparison_validate.return_value = mock_comparison_config
+
+            mock_pool.return_value = [
+                PipelineEvaluationResult(
+                    filename="test.mp4",
+                    correct=True,
+                    raw_result="otter",
+                    label="otter",
+                    comparison_method="exact",
+                    processing_time_seconds=1.5,
+                ),
+            ]
+
+            summary = evaluate_ai_pipeline(
+                config_path=config_file,
+                comparison_config_path=comparison_config_file,
+                labels_path=labels_file,
+                video_dir=data_directory,
+                max_workers=1,
+            )
+
+            json_output = summary.model_dump_json(indent=2)
+            assert "test.mp4" in json_output
+            assert "correct" in json_output
+            assert "processing_time_seconds" in json_output
+            assert "average_processing_time_seconds" in json_output
+            assert "success_rate" not in json_output
+            assert "failure_count" not in json_output


### PR DESCRIPTION
## Summary
Updates the AI pipeline evaluation to output a structured JSON summary instead of a JSONL file.

### Key Changes
- **Output Format**: Changed the evaluation output from JSONL to a single JSON object containing both the summary statistics and detailed per-video results.
- **Pydantic Integration**: Refactored `PipelineEvaluationResult` and `PipelineEvaluationSummary` to use Pydantic `BaseModel` for easier serialization and validation.
- **Performance Tracking**: Added tracking for individual video processing time and calculated average processing time across the evaluation set.
- **Enhanced Summary**: Added `success_rate` and `failure_count` properties to the evaluation summary.
- **CLI Updates**: Updated the `run-evaluate` command to handle the new JSON output and allow outputting directly to stdout or a file.
- **Testing**: Added comprehensive tests for JSON serialization, processing time calculation, and CLI output handling.

Detailed results are now captured within the `results` list of the output JSON file.