### PR TITLE
Evaluate outside pool

### DIFF
--- a/src/wildcamtools/lib/ai/label_comparison.py
+++ b/src/wildcamtools/lib/ai/label_comparison.py
@@ -33,9 +33,12 @@ class AbstractLabelComparator(ABC):
 
         if result_lower in ABSENCE_MARKERS:
             if label_lower in ABSENCE_MARKERS:
-                return True, ResultClassification.NO_ANIMAL
+                return True, ResultClassification.CORRECT
             else:
-                return False, ResultClassification.NO_ANIMAL
+                return False, ResultClassification.INCORRECT
+
+        if result_lower == label_lower:
+            return True, ResultClassification.CORRECT
 
         return None
 
@@ -50,7 +53,7 @@ class AbstractLabelComparator(ABC):
         Returns:
             Tuple of (is_correct, classification) where:
             - is_correct: True if the result matches the label
-            - classification: The type of result (correct, incorrect, unknown, no_animal)
+            - classification: The type of result (correct, incorrect, unknown)
         """
         ...
 
@@ -69,10 +72,7 @@ class ExactLabelComparator(AbstractLabelComparator):
         if special_case is not None:
             return special_case
 
-        if result.lower() == label.lower():
-            return True, ResultClassification.CORRECT
-        else:
-            return False, ResultClassification.INCORRECT
+        return False, ResultClassification.INCORRECT
 
     @property
     def method_name(self) -> str:

--- a/src/wildcamtools/lib/ai/pipeline_evaluation.py
+++ b/src/wildcamtools/lib/ai/pipeline_evaluation.py
@@ -33,6 +33,16 @@ class _FrameSelectorWrapper(FrameSelector):
         return self._frame_ids.copy()
 
 
+class _WorkerResult(BaseModel):
+    """Result from worker process before label comparison."""
+
+    filename: str
+    raw_result: str
+    processing_time_seconds: float = 0.0
+    frame_ids: list[int] = Field(default_factory=list)
+    error: str | None = None
+
+
 class PipelineEvaluationResult(BaseModel):
     filename: str
     classification: ResultClassification
@@ -54,7 +64,6 @@ class PipelineEvaluationSummary(BaseModel):
     correct_count: int = 0
     incorrect_count: int = 0
     unknown_count: int = 0
-    no_animal_count: int = 0
     total_count: int = 0
     error_count: int = 0
     average_processing_time_seconds: float = 0.0
@@ -85,7 +94,7 @@ class PipelineEvaluationSummary(BaseModel):
 
     @property
     def precision_when_confident(self) -> float:
-        confident_total = self.correct_count + self.incorrect_count + self.no_animal_count
+        confident_total = self.correct_count + self.incorrect_count
         if confident_total == 0:
             return 0.0
         return self.correct_count / confident_total
@@ -96,7 +105,6 @@ class PipelineEvaluationSummary(BaseModel):
         logger.info("  Correct: %d", self.correct_count)
         logger.info("  Incorrect: %d", self.incorrect_count)
         logger.info("  Unknown: %d", self.unknown_count)
-        logger.info("  No Animal: %d", self.no_animal_count)
         logger.info("  Errors: %d", self.error_count)
         logger.info("  Accuracy: %.4f", self.accuracy)
         logger.info("  Detection Rate: %.4f", self.detection_rate)
@@ -106,10 +114,8 @@ class PipelineEvaluationSummary(BaseModel):
 
 def _evaluate_video_worker(
     video_path_str: str,
-    ground_truth_label: str,
     pipeline_config: AiPipelineConfig,
-    comparator_config: LabelComparisonConfig,
-) -> PipelineEvaluationResult:
+) -> _WorkerResult:
     video_path = Path(video_path_str)
     try:
         start_time = time.time()
@@ -121,7 +127,6 @@ def _evaluate_video_worker(
         processing_time = end_time - start_time
         frame_ids = wrapper.frame_ids
 
-        # TODO this more cleanly - base class with a abstract method?
         if isinstance(result, SpeciesResult) or hasattr(result, "species_name"):
             raw_result = result.species_name
         elif hasattr(result, "message"):
@@ -129,28 +134,19 @@ def _evaluate_video_worker(
         else:
             raw_result = str(result)
 
-        comparator = comparator_config.create_comparator()
-        is_correct, classification = comparator.compare(raw_result, ground_truth_label)
         logger.info(
-            "Video %s: label=%s, result=%s, classification=%s (method=%s), frames=%s",
+            "Video %s: result=%s, frames=%s",
             video_path.name,
-            ground_truth_label,
             raw_result,
-            classification.value,
-            comparator.method_name,
             frame_ids,
         )
 
-        return PipelineEvaluationResult(
+        return _WorkerResult(
             filename=video_path.name,
-            classification=classification,
             raw_result=raw_result,
-            label=ground_truth_label,
-            error=None,
-            comparison_method=comparator.method_name,
             processing_time_seconds=processing_time,
             frame_ids=frame_ids,
-            is_correct=is_correct,
+            error=None,
         )
     except Exception:
         logger.exception("Worker failed for video %s", video_path.name)
@@ -181,6 +177,7 @@ def _run_worker_pool(
 ) -> list[PipelineEvaluationResult]:
     ctx = multiprocessing.get_context("spawn")
     results: list[PipelineEvaluationResult] = []
+    comparator = comparison_config.create_comparator()
 
     with ctx.Pool(processes=max_workers) as pool:
         futures = []
@@ -191,28 +188,30 @@ def _run_worker_pool(
                 continue
             future = pool.apply_async(
                 _evaluate_video_worker,
-                args=(str(video_path), label, pipeline_config, comparison_config),
+                args=(str(video_path), pipeline_config),
             )
-            futures.append(future)
+            futures.append((label, future))
 
-        for future in futures:
+        for label, future in futures:
             try:
-                result = future.get()
-                results.append(result)
-            except Exception as e:
+                worker_result = future.get()
+            except Exception:
                 logger.exception("Worker task failed")
-                results.append(
-                    PipelineEvaluationResult(
-                        filename="unknown",
-                        classification=ResultClassification.INCORRECT,
-                        raw_result="",
-                        label="unknown",
-                        error=str(e),
-                        comparison_method="exact",
-                        processing_time_seconds=0.0,
-                        frame_ids=[],
-                    )
+                continue
+            is_correct, classification = comparator.compare(worker_result.raw_result, label)
+            results.append(
+                PipelineEvaluationResult(
+                    filename=worker_result.filename,
+                    classification=classification,
+                    raw_result=worker_result.raw_result,
+                    label=label,
+                    error=worker_result.error,
+                    comparison_method=comparator.method_name,
+                    processing_time_seconds=worker_result.processing_time_seconds,
+                    frame_ids=worker_result.frame_ids,
+                    is_correct=is_correct,
                 )
+            )
 
     return results
 
@@ -263,7 +262,6 @@ def evaluate_ai_pipeline(
     correct_count = sum(1 for r in results if r.classification == ResultClassification.CORRECT)
     incorrect_count = sum(1 for r in results if r.classification == ResultClassification.INCORRECT)
     unknown_count = sum(1 for r in results if r.classification == ResultClassification.UNKNOWN)
-    no_animal_count = sum(1 for r in results if r.classification == ResultClassification.NO_ANIMAL)
     error_count = sum(1 for r in results if r.error is not None)
     total_count = len(results)
     total_processing_time = sum(r.processing_time_seconds for r in results)
@@ -274,7 +272,6 @@ def evaluate_ai_pipeline(
         correct_count=correct_count,
         incorrect_count=incorrect_count,
         unknown_count=unknown_count,
-        no_animal_count=no_animal_count,
         total_count=total_count,
         error_count=error_count,
         average_processing_time_seconds=average_processing_time,

--- a/src/wildcamtools/lib/ai/types.py
+++ b/src/wildcamtools/lib/ai/types.py
@@ -27,15 +27,37 @@ class ResultList(BaseModel):
 
 
 class BoolResponse(BaseModel):
-    answer: bool
+    answer: Annotated[
+        bool,
+        Field(
+            description="Boolean response to a yes/no question. Return false when the condition is not met, "
+            "when nothing is detected, or when you cannot confidently confirm.",
+            examples=[True, False],
+        ),
+    ]
 
 
 class StringResponse(BaseModel):
-    message: str
+    message: Annotated[
+        str,
+        Field(
+            description="Text response that can express uncertainty. Use 'unknown' when you cannot confidently "
+            "identify something, 'no animal' when nothing is present, or provide a specific identification.",
+            examples=["unknown", "no animal", "European Badger"],
+        ),
+    ]
 
 
 class SpeciesResult(BaseModel):
-    species_name: str
+    species_name: Annotated[
+        str,
+        Field(
+            description="Identified wildlife species from camera trap images. Return a specific species name when "
+            "confident (e.g., 'European Badger', 'Red Fox', 'Wood Pigeon'). Return 'unknown' when you cannot "
+            "confidently identify the species. Return 'no animal' when no animal is present in the image.",
+            examples=["European Badger", "Red Fox", "unknown", "no animal"],
+        ),
+    ]
 
 
 class ConfidenceLevel(StrEnum):
@@ -45,13 +67,47 @@ class ConfidenceLevel(StrEnum):
 
 
 class VerificationResult(BaseModel):
-    species_name: str
-    confidence: ConfidenceLevel
-    verified: bool
+    species_name: Annotated[
+        str,
+        Field(
+            description="Verified species identification. Use the confirmed species name when verified is true, "
+            "or 'unknown' when verification fails or confidence is too low.",
+            examples=["European Badger", "unknown"],
+        ),
+    ]
+    confidence: Annotated[
+        ConfidenceLevel,
+        Field(
+            description="Your confidence level in this verification: 'high' for >80% confidence, "
+            "'medium' for 50-80% confidence with some uncertainty, 'low' for <50% confidence or significant doubts.",
+            examples=["high", "medium", "low"],
+        ),
+    ]
+    verified: Annotated[
+        bool,
+        Field(
+            description="Whether you confirm the initial classification is correct. Set to false when the "
+            "classification is incorrect, when confidence is low, or when you cannot verify it.",
+            examples=[True, False],
+        ),
+    ]
 
 
 class ResultClassification(StrEnum):
     CORRECT = "correct"
     INCORRECT = "incorrect"
     UNKNOWN = "unknown"
-    NO_ANIMAL = "no_animal"
+
+
+__all__ = [
+    "Backend",
+    "BoolResponse",
+    "ConfidenceLevel",
+    "FrameResult",
+    "Result",
+    "ResultClassification",
+    "ResultList",
+    "SpeciesResult",
+    "StringResponse",
+    "VerificationResult",
+]

--- a/tests/lib/ai/test_label_comparison.py
+++ b/tests/lib/ai/test_label_comparison.py
@@ -29,19 +29,6 @@ class TestExactLabelComparator:
         assert comparator.compare("Uncertain", "dog") == (False, ResultClassification.UNKNOWN)
         assert comparator.compare("unsure", "bird") == (False, ResultClassification.UNKNOWN)
 
-    def test_no_animal_result_matches_no_animal_label(self) -> None:
-        comparator = ExactLabelComparator()
-        assert comparator.compare("none", "none") == (True, ResultClassification.NO_ANIMAL)
-        assert comparator.compare("no animal", "no") == (True, ResultClassification.NO_ANIMAL)
-        assert comparator.compare("", "empty") == (True, ResultClassification.NO_ANIMAL)
-        assert comparator.compare("missing", "") == (True, ResultClassification.NO_ANIMAL)
-
-    def test_no_animal_result_matches_animal_label(self) -> None:
-        comparator = ExactLabelComparator()
-        assert comparator.compare("none", "cat") == (False, ResultClassification.NO_ANIMAL)
-        assert comparator.compare("no animal", "dog") == (False, ResultClassification.NO_ANIMAL)
-        assert comparator.compare("missing", "bird") == (False, ResultClassification.NO_ANIMAL)
-
     def test_method_name(self) -> None:
         comparator = ExactLabelComparator()
         assert comparator.method_name == "exact"
@@ -81,19 +68,14 @@ class TestLLMLabelComparator:
         assert comparator.compare("unknown", "cat") == (False, ResultClassification.UNKNOWN)
         assert comparator.compare("uncertain", "dog") == (False, ResultClassification.UNKNOWN)
 
-    def test_no_animal_result(self, mock_llm: MagicMock) -> None:
-        comparator = LLMLabelComparator(llm=mock_llm)
-        assert comparator.compare("none", "none") == (True, ResultClassification.NO_ANIMAL)
-        assert comparator.compare("no animal", "cat") == (False, ResultClassification.NO_ANIMAL)
-
     def test_caching(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
 
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         assert mock_llm.message_with_schema.call_count == 1
 
@@ -103,9 +85,9 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
         comparator.clear_cache()
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         assert mock_llm.message_with_schema.call_count == 2
 
@@ -115,29 +97,29 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         assert mock_llm.message_with_schema.call_count == 2
         assert comparator._cache is None
 
-    def test_invalid_json_response(self, mock_llm: MagicMock) -> None:
+    def test_llm_call_made_for_semantic_comparison(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
 
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         assert mock_llm.message_with_schema.call_count == 1
 
-    def test_missing_match_field_raises_error(self, mock_llm: MagicMock) -> None:
+    def test_llm_call_with_false_response(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
 
         mock_response = BoolResponse(answer=False)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         assert mock_llm.message_with_schema.call_count == 1
 
@@ -148,11 +130,11 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         mock_llm.message_with_schema.assert_called_once()
         call_args = mock_llm.message_with_schema.call_args
-        assert call_args.kwargs["message"] == "Custom prompt: cat vs cat"
+        assert call_args.kwargs["message"] == "Custom prompt: domestic cat vs cat"
 
     def test_default_prompt(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
@@ -160,7 +142,7 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("cat", "cat")
+        comparator.compare("domestic cat", "cat")
 
         call_args = mock_llm.message_with_schema.call_args
         assert "You are comparing an AI classification result" in call_args.kwargs["message"]
@@ -175,7 +157,7 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("Cat", "CAT")
-        comparator.compare("cat", "cat")
+        comparator.compare("Domestic Cat", "CAT")
+        comparator.compare("domestic cat", "cat")
 
         assert mock_llm.message_with_schema.call_count == 1

--- a/tests/lib/ai/test_pipeline_evaluation.py
+++ b/tests/lib/ai/test_pipeline_evaluation.py
@@ -17,9 +17,49 @@ from wildcamtools.lib.ai.pipeline_config import AiPipelineConfig
 from wildcamtools.lib.ai.pipeline_evaluation import (
     _evaluate_video_worker,
     _FrameSelectorWrapper,
+    _WorkerResult,
     evaluate_ai_pipeline,
 )
 from wildcamtools.lib.ai.types import ResultClassification
+
+
+class TestWorkerResult:
+    def test_worker_result_creation(self) -> None:
+        result = _WorkerResult(
+            filename="test.mp4",
+            raw_result="otter",
+        )
+        assert result.filename == "test.mp4"
+        assert result.raw_result == "otter"
+        assert result.error is None
+        assert result.processing_time_seconds == 0.0
+        assert result.frame_ids == []
+
+    def test_worker_result_with_error(self) -> None:
+        result = _WorkerResult(
+            filename="test.mp4",
+            raw_result="",
+            error="Connection timeout",
+        )
+        assert result.error == "Connection timeout"
+        assert result.processing_time_seconds == 0.0
+        assert result.frame_ids == []
+
+    def test_worker_result_with_processing_time(self) -> None:
+        result = _WorkerResult(
+            filename="test.mp4",
+            raw_result="otter",
+            processing_time_seconds=1.5,
+        )
+        assert result.processing_time_seconds == 1.5
+
+    def test_worker_result_with_frame_ids(self) -> None:
+        result = _WorkerResult(
+            filename="test.mp4",
+            raw_result="otter",
+            frame_ids=[1, 5, 10, 15],
+        )
+        assert result.frame_ids == [1, 5, 10, 15]
 
 
 class TestPipelineEvaluationResult:
@@ -65,18 +105,6 @@ class TestPipelineEvaluationResult:
         )
         assert result.classification == ResultClassification.UNKNOWN
         assert result.correct is False
-
-    def test_result_no_animal_classification(self) -> None:
-        result = PipelineEvaluationResult(
-            filename="test.mp4",
-            classification=ResultClassification.NO_ANIMAL,
-            raw_result="none",
-            label="none",
-            is_correct=True,
-        )
-        assert result.classification == ResultClassification.NO_ANIMAL
-        assert result.is_correct is True
-        assert result.correct is True
 
     def test_result_with_comparison_method(self) -> None:
         result = PipelineEvaluationResult(
@@ -187,7 +215,6 @@ class TestPipelineEvaluationSummary:
             correct_count=1,
             incorrect_count=1,
             unknown_count=0,
-            no_animal_count=0,
             total_count=2,
             error_count=0,
         )
@@ -226,7 +253,6 @@ class TestPipelineEvaluationSummary:
             correct_count=2,
             incorrect_count=1,
             unknown_count=0,
-            no_animal_count=0,
             total_count=3,
             error_count=0,
         )
@@ -261,7 +287,6 @@ class TestPipelineEvaluationSummary:
             correct_count=1,
             incorrect_count=1,
             unknown_count=1,
-            no_animal_count=0,
             total_count=3,
             error_count=0,
         )
@@ -290,7 +315,6 @@ class TestPipelineEvaluationSummary:
             correct_count=1,
             incorrect_count=0,
             unknown_count=0,
-            no_animal_count=0,
             total_count=2,
             error_count=1,
         )
@@ -332,7 +356,6 @@ class TestPipelineEvaluationSummary:
             correct_count=correct,
             incorrect_count=incorrect,
             unknown_count=0,
-            no_animal_count=0,
             total_count=total,
             error_count=0,
         )
@@ -360,7 +383,6 @@ class TestPipelineEvaluationSummary:
             correct_count=2,
             incorrect_count=0,
             unknown_count=0,
-            no_animal_count=0,
             total_count=3,
             error_count=0,
         )
@@ -388,7 +410,6 @@ class TestPipelineEvaluationSummary:
             correct_count=1,
             incorrect_count=1,
             unknown_count=0,
-            no_animal_count=0,
             total_count=3,
             error_count=0,
         )
@@ -423,7 +444,6 @@ class TestPipelineEvaluationSummary:
             correct_count=1,
             incorrect_count=1,
             unknown_count=1,
-            no_animal_count=0,
             total_count=3,
             error_count=0,
         )
@@ -445,24 +465,16 @@ class TestPipelineEvaluationSummary:
                 label="cat",
                 is_correct=False,
             ),
-            PipelineEvaluationResult(
-                filename="test3.mp4",
-                classification=ResultClassification.NO_ANIMAL,
-                raw_result="none",
-                label="otter",
-                is_correct=True,
-            ),
         ]
         summary = PipelineEvaluationSummary(
             results=results,
             correct_count=1,
             incorrect_count=1,
             unknown_count=0,
-            no_animal_count=1,
-            total_count=3,
+            total_count=2,
             error_count=0,
         )
-        assert summary.precision_when_confident == pytest.approx(1 / 3)
+        assert summary.precision_when_confident == pytest.approx(1 / 2)
 
     def test_average_processing_time(self) -> None:
         results = [
@@ -496,7 +508,6 @@ class TestPipelineEvaluationSummary:
             correct_count=3,
             incorrect_count=0,
             unknown_count=0,
-            no_animal_count=0,
             total_count=3,
             error_count=0,
             average_processing_time_seconds=2.0,
@@ -519,7 +530,6 @@ class TestPipelineEvaluationSummary:
             correct_count=1,
             incorrect_count=0,
             unknown_count=0,
-            no_animal_count=0,
             total_count=1,
             error_count=0,
             average_processing_time_seconds=1.5,
@@ -542,20 +552,11 @@ class TestEvaluateVideoWorker:
         mock_pipeline.run.return_value = mock_result
         mock_config.create_pipeline.return_value = mock_pipeline
 
-        mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = (True, ResultClassification.CORRECT)
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
         video_path = data_directory / "test.mp4"
-        result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        result = _evaluate_video_worker(str(video_path), mock_config)
 
         assert result.filename == "test.mp4"
-        assert result.classification == ResultClassification.CORRECT
-        assert result.correct is True
         assert result.raw_result == "otter"
-        assert result.label == "otter"
         assert result.error is None
         assert result.processing_time_seconds > 0.0
 
@@ -569,19 +570,10 @@ class TestEvaluateVideoWorker:
         mock_pipeline.run.return_value = mock_result
         mock_config.create_pipeline.return_value = mock_pipeline
 
-        mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = (False, ResultClassification.INCORRECT)
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
         video_path = data_directory / "test.mp4"
-        result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        result = _evaluate_video_worker(str(video_path), mock_config)
 
-        assert result.classification == ResultClassification.INCORRECT
-        assert result.correct is False
         assert result.raw_result == "cat"
-        assert result.label == "otter"
 
     def test_worker_unknown_result_with_mock(
         self,
@@ -593,40 +585,10 @@ class TestEvaluateVideoWorker:
         mock_pipeline.run.return_value = mock_result
         mock_config.create_pipeline.return_value = mock_pipeline
 
-        mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = (False, ResultClassification.UNKNOWN)
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
         video_path = data_directory / "test.mp4"
-        result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        result = _evaluate_video_worker(str(video_path), mock_config)
 
-        assert result.classification == ResultClassification.UNKNOWN
-        assert result.correct is False
         assert result.raw_result == "unknown"
-
-    def test_worker_case_insensitive_comparison_with_mock(
-        self,
-        data_directory: Path,
-    ) -> None:
-        mock_result = SpeciesResult(species_name="Otter")
-        mock_config = MagicMock()
-        mock_pipeline = MagicMock()
-        mock_pipeline.run.return_value = mock_result
-        mock_config.create_pipeline.return_value = mock_pipeline
-
-        mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = (True, ResultClassification.CORRECT)
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
-        video_path = data_directory / "test.mp4"
-        result = _evaluate_video_worker(str(video_path), "OTTER", mock_config, mock_comparison_config)
-
-        assert result.classification == ResultClassification.CORRECT
-        assert result.correct is True
 
     def test_worker_error_handling_with_mock(
         self,
@@ -637,14 +599,9 @@ class TestEvaluateVideoWorker:
         mock_pipeline.run.side_effect = RuntimeError("LLM connection failed")
         mock_config.create_pipeline.return_value = mock_pipeline
 
-        mock_comparator = MagicMock()
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
         video_path = data_directory / "test.mp4"
         with pytest.raises(RuntimeError, match="LLM connection failed"):
-            _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+            _evaluate_video_worker(str(video_path), mock_config)
 
     def test_worker_with_string_response_result(
         self,
@@ -656,18 +613,10 @@ class TestEvaluateVideoWorker:
         mock_pipeline.run.return_value = mock_result
         mock_config.create_pipeline.return_value = mock_pipeline
 
-        mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = (True, ResultClassification.CORRECT)
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
         video_path = data_directory / "test.mp4"
-        result = _evaluate_video_worker(str(video_path), "test response", mock_config, mock_comparison_config)
+        result = _evaluate_video_worker(str(video_path), mock_config)
 
         assert result.raw_result == "test response"
-        assert result.classification == ResultClassification.CORRECT
-        assert result.correct is True
 
     def test_worker_captures_frame_ids(
         self,
@@ -693,14 +642,8 @@ class TestEvaluateVideoWorker:
         mock_pipeline.run.side_effect = run_side_effect
         mock_config.create_pipeline.return_value = mock_pipeline
 
-        mock_comparator = MagicMock()
-        mock_comparator.compare.return_value = (True, ResultClassification.CORRECT)
-        mock_comparator.method_name = "exact"
-        mock_comparison_config = MagicMock()
-        mock_comparison_config.create_comparator.return_value = mock_comparator
-
         video_path = data_directory / "test.mp4"
-        result = _evaluate_video_worker(str(video_path), "otter", mock_config, mock_comparison_config)
+        result = _evaluate_video_worker(str(video_path), mock_config)
 
         assert result.frame_ids == [1, 5, 10]
 


### PR DESCRIPTION
Move label comparison logic out of the worker pool and into the main process to avoid creating comparator instances in every worker and to simplify worker inputs.