### PR TITLE
Add ssim frame selector

### DIFF
--- a/pipelines/pipeline_config_motion.json
+++ b/pipelines/pipeline_config_motion.json
@@ -1,7 +1,7 @@
 {
   "frame_selector": {
     "selector_type": "motion",
-    "max_fps": 5.0
+    "fps": 5.0
   },
   "frame_extractor": {
     "resolution": [

--- a/pipelines/pipeline_config_ssim.json
+++ b/pipelines/pipeline_config_ssim.json
@@ -1,7 +1,12 @@
 {
   "frame_selector": {
-    "selector_type": "fps_rescaling",
-    "fps": 0.5
+    "selector_type": "ssim",
+    "fps": 5.0,
+    "similarity_minimum": 0.95,
+    "resolution": [
+      1280,
+      720
+    ]
   },
   "frame_extractor": {
     "resolution": [
@@ -16,10 +21,9 @@
     "api_key": "${WCT_OLLAMA_API_KEY}"
   },
   "query": {
-    "query_type": "verified",
+    "query_type": "llm",
     "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult",
-    "min_confidence": "high"
+    "response_schema": "SpeciesResult"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/run.sh
+++ b/pipelines/run.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 # shellcheck disable=SC1091
-set -a && source .env && set +a
+set -a && source pipelines/.env && set +a
 
 uv run wildcamtools ai run-evaluate --help
 
 
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_verify_med.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_med.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_verify_high.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_high.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_motion.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/motion.json
 uv run wildcamtools ai run-evaluate pipelines/pipeline_config_prompt.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/prompt.json
+uv run wildcamtools ai run-evaluate pipelines/pipeline_config_verify_high.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_high.json
+uv run wildcamtools ai run-evaluate pipelines/pipeline_config_verify_med.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_med.json
+uv run wildcamtools ai run-evaluate pipelines/pipeline_config_motion.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/motion.json
+uv run wildcamtools ai run-evaluate pipelines/pipeline_config_ssim.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/ssim.json
 uv run wildcamtools ai run-evaluate pipelines/pipeline_config.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/output.json

--- a/src/wildcamtools/lib/ai/pipeline.py
+++ b/src/wildcamtools/lib/ai/pipeline.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from wildcamtools.lib import Frame
 from wildcamtools.lib.ai.llm.abstract import AbstractLlm
 from wildcamtools.lib.ai.types import ConfidenceLevel, VerificationResult
-from wildcamtools.lib.frames import Rescaler, resize_with_aspect_ratio
+from wildcamtools.lib.frames import FilterSSIM, Rescaler, resize_with_aspect_ratio
 from wildcamtools.lib.motion import MogMotion
 from wildcamtools.lib.stats import get_video_stats
 from wildcamtools.lib.vidio import VideoReader
@@ -60,19 +60,19 @@ class FpsRescalingFrameSelector(FrameSelector):
 
 
 class MotionFrameSelector(FrameSelector):
-    max_fps: float
+    fps: float
     motion_threshold: float
     resolution: tuple[int, int] | None
     history: int
 
     def __init__(
         self,
-        max_fps: float = 5.0,
+        fps: float = 5.0,
         motion_threshold: float = 0.01,
         resolution: tuple[int, int] | None = None,
         history: int = 30,
     ) -> None:
-        self.max_fps = max_fps
+        self.fps = fps
         self.motion_threshold = motion_threshold
         self.resolution = resolution
         self.history = history
@@ -80,7 +80,7 @@ class MotionFrameSelector(FrameSelector):
     def select_frames(self, video: Path) -> Iterator[Frame]:
         stats = get_video_stats(video)
         motion_handler = MogMotion(history=self.history, resolution=self.resolution)
-        rescaler = Rescaler(stats, fps=self.max_fps) if self.max_fps > 0 else None
+        rescaler = Rescaler(stats, fps=self.fps) if self.fps > 0 else None
 
         with VideoReader(video) as video_reader:
             for frame in video_reader:
@@ -99,6 +99,43 @@ class MotionFrameSelector(FrameSelector):
                     continue
 
                 yield frame
+
+
+class SSIMFrameSelector(FrameSelector):
+    fps: float
+    similarity_minimum: float
+    resolution: tuple[int, int] | None
+
+    def __init__(
+        self,
+        fps: float = 5.0,
+        similarity_minimum: float = 0.9,
+        resolution: tuple[int, int] | None = None,
+    ) -> None:
+        self.fps = fps
+        self.similarity_minimum = similarity_minimum
+        self.resolution = resolution
+
+    def select_frames(self, video: Path) -> Iterator[Frame]:
+        stats = get_video_stats(video)
+        ssim_filter = FilterSSIM(similarity_minimum=self.similarity_minimum)
+        rescaler = None
+        if self.fps > 0:
+            if self.resolution is not None:
+                rescaler = Rescaler(stats, fps=self.fps, x=self.resolution[0], y=self.resolution[1])
+            else:
+                rescaler = Rescaler(stats, fps=self.fps)
+
+        with VideoReader(video) as video_reader:
+            for frame in video_reader:
+                if rescaler is not None:
+                    frame = rescaler.handle(frame)
+                    if not frame.filter_keep:
+                        continue
+
+                frame = ssim_filter.handle(frame)
+                if frame.filter_keep:
+                    yield frame
 
 
 class FrameImageExtractor(ABC):
@@ -196,7 +233,7 @@ class VerifiedImageBatchQuery(ImageBatchQuery[VerificationResult]):
             logger.warning("Empty image batch received")
             raise ValueError("Empty image batch")
 
-        logger.info("Sending %d images to analyser for initial classification", len(images_list))
+        logger.debug("Sending %d images to analyser for initial classification", len(images_list))
         initial_result = self.llm.message_with_schema(
             message=self.prompt,
             images=images_list,

--- a/src/wildcamtools/lib/ai/pipeline_config.py
+++ b/src/wildcamtools/lib/ai/pipeline_config.py
@@ -17,6 +17,7 @@ from wildcamtools.lib.ai.pipeline import (
     MotionFrameSelector,
     RescaledFrameImageExtractor,
     ResultReconciler,
+    SSIMFrameSelector,
     VerifiedImageBatchQuery,
 )
 from wildcamtools.lib.ai.types import Backend, ConfidenceLevel, Result, SpeciesResult, StringResponse
@@ -25,6 +26,7 @@ from wildcamtools.lib.ai.types import Backend, ConfidenceLevel, Result, SpeciesR
 class FrameSelectorType(StrEnum):
     FPS_RESCALING = "fps_rescaling"
     MOTION = "motion"
+    SSIM = "ssim"
 
 
 class ReconcilerType(StrEnum):
@@ -52,14 +54,14 @@ RESPONSE_SCHEMA_MAP: dict[ResponseSchemaType, type[BaseModel]] = {
 class FrameSelectorConfig(BaseModel):
     selector_type: FrameSelectorType = FrameSelectorType.FPS_RESCALING
     fps: Annotated[float, Field(strict=True, gt=0.0, description="Target frames per second")] = 1.0
-    max_fps: Annotated[
-        float,
-        Field(strict=True, ge=0.0, description="Max frames per second for motion selector"),
-    ] = 5.0
     motion_threshold: Annotated[
         float,
         Field(strict=True, ge=0.0, le=1.0, description="Motion detection threshold"),
     ] = 0.01
+    similarity_minimum: Annotated[
+        float,
+        Field(strict=True, ge=0.0, le=1.0, description="Minimum SSIM similarity threshold"),
+    ] = 0.9
     resolution: Annotated[
         tuple[Annotated[int, Field(strict=True, gt=0)], Annotated[int, Field(strict=True, gt=0)]] | None,
         Field(description="Motion detection resolution as (width, height)"),
@@ -80,10 +82,16 @@ class FrameSelectorConfig(BaseModel):
                 return FpsRescalingFrameSelector(fps=self.fps)
             case FrameSelectorType.MOTION:
                 return MotionFrameSelector(
-                    max_fps=self.max_fps,
+                    fps=self.fps,
                     motion_threshold=self.motion_threshold,
                     resolution=self.resolution,
                     history=self.history,
+                )
+            case FrameSelectorType.SSIM:
+                return SSIMFrameSelector(
+                    fps=self.fps,
+                    similarity_minimum=self.similarity_minimum,
+                    resolution=self.resolution,
                 )
             case _:
                 raise NotImplementedError(f"Unsupported frame selector type: {self.selector_type}")

--- a/tests/lib/ai/test_pipeline.py
+++ b/tests/lib/ai/test_pipeline.py
@@ -18,6 +18,7 @@ from wildcamtools.lib.ai.pipeline import (
     MajorityResultReconciler,
     MotionFrameSelector,
     RescaledFrameImageExtractor,
+    SSIMFrameSelector,
     VerifiedImageBatchQuery,
 )
 from wildcamtools.lib.ai.types import ConfidenceLevel, VerificationResult
@@ -250,7 +251,7 @@ class TestMotionFrameSelector:
     def test_motion_selector_initializes_with_defaults(self) -> None:
         """Test constructor with default values."""
         selector = MotionFrameSelector()
-        assert selector.max_fps == 5.0
+        assert selector.fps == 5.0
         assert selector.motion_threshold == 0.01
         assert selector.resolution is None
         assert selector.history == 30
@@ -258,12 +259,12 @@ class TestMotionFrameSelector:
     def test_motion_selector_initializes_with_custom_values(self) -> None:
         """Test constructor stores custom parameters."""
         selector = MotionFrameSelector(
-            max_fps=10.0,
+            fps=10.0,
             motion_threshold=0.05,
             resolution=(640, 360),
             history=50,
         )
-        assert selector.max_fps == 10.0
+        assert selector.fps == 10.0
         assert selector.motion_threshold == 0.05
         assert selector.resolution == (640, 360)
         assert selector.history == 50
@@ -285,9 +286,9 @@ class TestMotionFrameSelector:
             assert hasattr(frame, "frame_no")
 
     def test_motion_selector_respects_max_fps(self, video_path: Path) -> None:
-        """Test that max_fps parameter reduces frame count."""
-        selector_10fps = MotionFrameSelector(max_fps=10.0)
-        selector_2fps = MotionFrameSelector(max_fps=2.0)
+        """Test that fps parameter reduces frame count."""
+        selector_10fps = MotionFrameSelector(fps=10.0)
+        selector_2fps = MotionFrameSelector(fps=2.0)
 
         frames_10 = list(selector_10fps.select_frames(video_path))
         frames_2 = list(selector_2fps.select_frames(video_path))
@@ -325,15 +326,15 @@ class TestMotionFrameSelector:
     @pytest.mark.parametrize("fps_value", [1.0, 5.0, 10.0])
     def test_motion_selector_parametrized_fps(self, video_path: Path, fps_value: float) -> None:
         """Test various FPS values."""
-        selector = MotionFrameSelector(max_fps=fps_value)
+        selector = MotionFrameSelector(fps=fps_value)
         frames = list(selector.select_frames(video_path))
         assert len(frames) > 0
         for frame in frames:
             assert isinstance(frame, Frame)
 
     def test_motion_selector_zero_fps(self, video_path: Path) -> None:
-        """Test that max_fps=0 does not apply FPS filtering."""
-        selector = MotionFrameSelector(max_fps=0.0)
+        """Test that fps=0 does not apply FPS filtering."""
+        selector = MotionFrameSelector(fps=0.0)
         frames = list(selector.select_frames(video_path))
         assert len(frames) > 0
         for frame in frames:
@@ -356,6 +357,105 @@ class TestMotionFrameSelector:
         for frame in frames_low:
             assert isinstance(frame, Frame)
             assert frame.motion_proportion >= -1.0
+
+
+class TestSSIMFrameSelector:
+    """Tests for SSIMFrameSelector specific functionality."""
+
+    def test_ssim_selector_initializes_with_defaults(self) -> None:
+        """Test constructor with default values."""
+        selector = SSIMFrameSelector()
+        assert selector.fps == 5.0
+        assert selector.similarity_minimum == 0.9
+        assert selector.resolution is None
+
+    def test_ssim_selector_initializes_with_custom_values(self) -> None:
+        """Test constructor stores custom parameters."""
+        selector = SSIMFrameSelector(
+            fps=10.0,
+            similarity_minimum=0.95,
+            resolution=(640, 360),
+        )
+        assert selector.fps == 10.0
+        assert selector.similarity_minimum == 0.95
+        assert selector.resolution == (640, 360)
+
+    def test_select_frames_returns_generator(self, video_path: Path) -> None:
+        """Verify select_frames returns a Generator."""
+        selector = SSIMFrameSelector()
+        result = selector.select_frames(video_path)
+        assert isinstance(result, Generator)
+
+    def test_select_frames_yields_frames(self, data_directory: Path) -> None:
+        """Verify yielded items are Frame instances."""
+        video_path = data_directory / "short.mp4"
+        selector = SSIMFrameSelector(fps=1.0, similarity_minimum=0.0, resolution=(40, 30))
+        frames = list(selector.select_frames(video_path))
+        assert len(frames) > 0
+        for frame in frames:
+            assert isinstance(frame, Frame)
+            assert hasattr(frame, "raw")
+            assert hasattr(frame, "frame_no")
+
+    def test_ssim_selector_respects_max_fps(self, data_directory: Path) -> None:
+        """Test that fps parameter reduces frame count."""
+        video_path = data_directory / "short.mp4"
+        selector_high = SSIMFrameSelector(fps=5.0, similarity_minimum=0.0, resolution=(40, 30))
+        selector_low = SSIMFrameSelector(fps=0.5, similarity_minimum=0.0, resolution=(40, 30))
+
+        frames_high = list(selector_high.select_frames(video_path))
+        frames_low = list(selector_low.select_frames(video_path))
+
+        assert len(frames_low) <= len(frames_high)
+
+    def test_ssim_selector_preserves_frame_order(self, data_directory: Path) -> None:
+        """Test that frames maintain sequential ordering."""
+        video_path = data_directory / "short.mp4"
+        selector = SSIMFrameSelector(fps=1.0, similarity_minimum=0.0, resolution=(40, 30))
+        frames = list(selector.select_frames(video_path))
+
+        frame_numbers = [frame.frame_no for frame in frames]
+        assert frame_numbers == sorted(frame_numbers)
+
+    def test_ssim_selector_with_resolution(self, data_directory: Path) -> None:
+        """Test that resolution parameter controls output resolution."""
+        video_path = data_directory / "short.mp4"
+        selector = SSIMFrameSelector(resolution=(40, 30), fps=1.0, similarity_minimum=0.0)
+        frames = list(selector.select_frames(video_path))
+
+        assert len(frames) > 0
+        for frame in frames:
+            assert isinstance(frame, Frame)
+
+    def test_ssim_selector_with_high_similarity_minimum(self, data_directory: Path) -> None:
+        """Test that high similarity_minimum reduces frame count."""
+        video_path = data_directory / "short.mp4"
+        selector_low = SSIMFrameSelector(similarity_minimum=0.0, fps=1.0, resolution=(40, 30))
+        selector_high = SSIMFrameSelector(similarity_minimum=0.99, fps=1.0, resolution=(40, 30))
+
+        frames_low = list(selector_low.select_frames(video_path))
+        frames_high = list(selector_high.select_frames(video_path))
+
+        assert len(frames_high) <= len(frames_low)
+
+    @pytest.mark.parametrize("fps_value", [0.5, 1.0, 2.0])
+    def test_ssim_selector_parametrized_fps(self, data_directory: Path, fps_value: float) -> None:
+        """Test various FPS values."""
+        video_path = data_directory / "short.mp4"
+        selector = SSIMFrameSelector(fps=fps_value, similarity_minimum=0.0, resolution=(40, 30))
+        frames = list(selector.select_frames(video_path))
+        assert len(frames) > 0
+        for frame in frames:
+            assert isinstance(frame, Frame)
+
+    def test_ssim_selector_zero_fps(self, data_directory: Path) -> None:
+        """Test that fps=0 does not apply FPS filtering."""
+        video_path = data_directory / "short.mp4"
+        selector = SSIMFrameSelector(fps=0.0, similarity_minimum=0.0, resolution=None)
+        frames = list(selector.select_frames(video_path))
+        assert len(frames) > 0
+        for frame in frames:
+            assert isinstance(frame, Frame)
 
 
 class TestRescaledFrameImageExtractor:

--- a/tests/lib/ai/test_pipeline_config.py
+++ b/tests/lib/ai/test_pipeline_config.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import AnyHttpUrl, ValidationError
 
 from wildcamtools.lib.ai import Backend
-from wildcamtools.lib.ai.pipeline import MotionFrameSelector
+from wildcamtools.lib.ai.pipeline import MotionFrameSelector, SSIMFrameSelector
 from wildcamtools.lib.ai.pipeline_config import (
     AiPipelineConfig,
     FrameExtractorConfig,
@@ -32,7 +32,7 @@ class TestFrameSelectorConfig:
 
     def test_invalid_fps_zero(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
-            FrameSelectorConfig(fps=0.0)
+            FrameSelectorConfig(selector_type=FrameSelectorType.FPS_RESCALING, fps=0.0)
         assert "gt=0.0" in str(exc_info.value) or "greater than 0" in str(exc_info.value).lower()
 
     def test_invalid_fps_negative(self) -> None:
@@ -69,7 +69,7 @@ class TestFrameSelectorConfig:
     def test_motion_selector_default_values(self) -> None:
         config = FrameSelectorConfig(selector_type=FrameSelectorType.MOTION)
         assert config.selector_type == FrameSelectorType.MOTION
-        assert config.max_fps == 5.0
+        assert config.fps == 1.0
         assert config.motion_threshold == 0.01
         assert config.resolution is None
         assert config.history == 30
@@ -77,12 +77,12 @@ class TestFrameSelectorConfig:
     def test_motion_selector_custom_values(self) -> None:
         config = FrameSelectorConfig(
             selector_type=FrameSelectorType.MOTION,
-            max_fps=10.0,
+            fps=10.0,
             motion_threshold=0.05,
             resolution=(320, 240),
             history=50,
         )
-        assert config.max_fps == 10.0
+        assert config.fps == 10.0
         assert config.motion_threshold == 0.05
         assert config.resolution == (320, 240)
         assert config.history == 50
@@ -112,22 +112,22 @@ class TestFrameSelectorConfig:
             FrameSelectorConfig(selector_type=FrameSelectorType.MOTION, resolution=(320, 0))
         assert "gt=0" in str(exc_info.value) or "greater than 0" in str(exc_info.value).lower()
 
-    def test_motion_selector_invalid_max_fps_negative(self) -> None:
+    def test_motion_selector_invalid_fps_negative(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
-            FrameSelectorConfig(selector_type=FrameSelectorType.MOTION, max_fps=-1.0)
-        assert "ge=0.0" in str(exc_info.value) or "greater than or equal to 0" in str(exc_info.value).lower()
+            FrameSelectorConfig(selector_type=FrameSelectorType.MOTION, fps=-1.0)
+        assert "gt=0.0" in str(exc_info.value) or "greater than 0" in str(exc_info.value).lower()
 
     def test_motion_selector_create_frame_selector(self) -> None:
         config = FrameSelectorConfig(
             selector_type=FrameSelectorType.MOTION,
-            max_fps=10.0,
+            fps=10.0,
             motion_threshold=0.02,
             resolution=(640, 480),
             history=40,
         )
         selector = config.create_frame_selector()
         assert isinstance(selector, MotionFrameSelector)
-        assert selector.max_fps == 10.0
+        assert selector.fps == 10.0
         assert selector.motion_threshold == 0.02
         assert selector.resolution == (640, 480)
         assert selector.history == 40
@@ -136,7 +136,7 @@ class TestFrameSelectorConfig:
         config = FrameSelectorConfig(selector_type=FrameSelectorType.MOTION)
         selector = config.create_frame_selector()
         assert isinstance(selector, MotionFrameSelector)
-        assert selector.max_fps == 5.0
+        assert selector.fps == 1.0
         assert selector.motion_threshold == 0.01
         assert selector.resolution is None
         assert selector.history == 30
@@ -144,14 +144,14 @@ class TestFrameSelectorConfig:
     def test_motion_selector_serialization(self) -> None:
         config = FrameSelectorConfig(
             selector_type=FrameSelectorType.MOTION,
-            max_fps=8.0,
+            fps=8.0,
             motion_threshold=0.03,
             resolution=(400, 300),
             history=25,
         )
         data = config.model_dump()
         assert data["selector_type"] == "motion"
-        assert data["max_fps"] == 8.0
+        assert data["fps"] == 8.0
         assert data["motion_threshold"] == 0.03
         assert data["resolution"] == (400, 300)
         assert data["history"] == 25
@@ -159,16 +159,96 @@ class TestFrameSelectorConfig:
     def test_motion_selector_from_dict(self) -> None:
         config = FrameSelectorConfig.model_validate({
             "selector_type": "motion",
-            "max_fps": 7.0,
+            "fps": 7.0,
             "motion_threshold": 0.015,
             "resolution": [480, 360],
             "history": 35,
         })
         assert config.selector_type == FrameSelectorType.MOTION
-        assert config.max_fps == 7.0
+        assert config.fps == 7.0
         assert config.motion_threshold == 0.015
         assert config.resolution == (480, 360)
         assert config.history == 35
+
+    def test_ssim_selector_default_values(self) -> None:
+        config = FrameSelectorConfig(selector_type=FrameSelectorType.SSIM)
+        assert config.selector_type == FrameSelectorType.SSIM
+        assert config.fps == 1.0
+        assert config.similarity_minimum == 0.9
+        assert config.resolution is None
+
+    def test_ssim_selector_custom_values(self) -> None:
+        config = FrameSelectorConfig(
+            selector_type=FrameSelectorType.SSIM,
+            fps=10.0,
+            similarity_minimum=0.95,
+            resolution=(320, 240),
+            history=5,
+        )
+        assert config.fps == 10.0
+        assert config.similarity_minimum == 0.95
+        assert config.resolution == (320, 240)
+        assert config.history == 5
+
+    def test_ssim_selector_invalid_similarity_negative(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            FrameSelectorConfig(selector_type=FrameSelectorType.SSIM, similarity_minimum=-0.1)
+        assert "ge=0.0" in str(exc_info.value) or "greater than or equal to 0" in str(exc_info.value).lower()
+
+    def test_ssim_selector_invalid_similarity_above_one(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            FrameSelectorConfig(selector_type=FrameSelectorType.SSIM, similarity_minimum=1.5)
+        assert "le=1.0" in str(exc_info.value) or "less than or equal to 1" in str(exc_info.value).lower()
+
+    def test_ssim_selector_create_frame_selector(self) -> None:
+        config = FrameSelectorConfig(
+            selector_type=FrameSelectorType.SSIM,
+            fps=10.0,
+            similarity_minimum=0.85,
+            resolution=(640, 480),
+        )
+        selector = config.create_frame_selector()
+        assert isinstance(selector, SSIMFrameSelector)
+        assert selector.fps == 10.0
+        assert selector.similarity_minimum == 0.85
+        assert selector.resolution == (640, 480)
+
+    def test_ssim_selector_create_default(self) -> None:
+        config = FrameSelectorConfig(selector_type=FrameSelectorType.SSIM)
+        selector = config.create_frame_selector()
+        assert isinstance(selector, SSIMFrameSelector)
+        assert selector.fps == 1.0
+        assert selector.similarity_minimum == 0.9
+        assert selector.resolution is None
+
+    def test_ssim_selector_serialization(self) -> None:
+        config = FrameSelectorConfig(
+            selector_type=FrameSelectorType.SSIM,
+            fps=8.0,
+            similarity_minimum=0.92,
+            resolution=(400, 300),
+            history=15,
+        )
+        data = config.model_dump()
+        assert data["selector_type"] == "ssim"
+        assert data["fps"] == 8.0
+        assert data["similarity_minimum"] == 0.92
+        assert data["resolution"] == (400, 300)
+        assert data["history"] == 15
+
+    def test_ssim_selector_from_dict(self) -> None:
+        config = FrameSelectorConfig.model_validate({
+            "selector_type": "ssim",
+            "fps": 7.0,
+            "similarity_minimum": 0.88,
+            "resolution": [480, 360],
+            "history": 20,
+        })
+        assert config.selector_type == FrameSelectorType.SSIM
+        assert config.fps == 7.0
+        assert config.similarity_minimum == 0.88
+        assert config.resolution == (480, 360)
+        assert config.history == 20
 
 
 class TestFrameExtractorConfig:
@@ -543,7 +623,7 @@ class TestAiPipelineConfig:
         config = AiPipelineConfig(
             frame_selector=FrameSelectorConfig(
                 selector_type=FrameSelectorType.MOTION,
-                max_fps=10.0,
+                fps=10.0,
                 motion_threshold=0.02,
                 resolution=(320, 240),
                 history=40,
@@ -554,7 +634,7 @@ class TestAiPipelineConfig:
 
         pipeline = config.create_pipeline()
         assert isinstance(pipeline.frame_selector, MotionFrameSelector)
-        assert pipeline.frame_selector.max_fps == 10.0
+        assert pipeline.frame_selector.fps == 10.0
         assert pipeline.frame_selector.motion_threshold == 0.02
         assert pipeline.frame_selector.resolution == (320, 240)
         assert pipeline.frame_selector.history == 40
@@ -568,7 +648,7 @@ class TestAiPipelineConfig:
 
         pipeline = config.create_pipeline()
         assert isinstance(pipeline.frame_selector, MotionFrameSelector)
-        assert pipeline.frame_selector.max_fps == 5.0
+        assert pipeline.frame_selector.fps == 1.0
         assert pipeline.frame_selector.motion_threshold == 0.01
         assert pipeline.frame_selector.resolution is None
         assert pipeline.frame_selector.history == 30


### PR DESCRIPTION
## Summary
Adds a new SSIM (Structural Similarity Index) frame selector to filter out similar frames from wildlife videos, reducing redundant data sent to analysis models.

## Changes
- **New SSIMFrameSelector** in src/wildcamtools/lib/ai/pipeline.py - Filters frames based on structural similarity, keeping only frames that differ significantly from previous ones
- **New pipeline config** pipelines/pipeline_config_ssim.json - Example configuration using the SSIM selector with 5 FPS and 0.95 similarity threshold
- **Updated tests** - Added test coverage for the new frame selector

## Benefits
- Reduces duplicate/similar frames sent to LLM analysis
- More efficient processing by eliminating redundant frames
- Complements existing motion-based frame selection