### PR TITLE
Add batch size limit to image extractor

### DIFF
--- a/src/wildcamtools/lib/ai/pipeline.py
+++ b/src/wildcamtools/lib/ai/pipeline.py
@@ -144,13 +144,15 @@ class FrameImageExtractor(ABC):
 
 
 class RescaledFrameImageExtractor(FrameImageExtractor):
-    def __init__(self, resolution: tuple[int, int] = (640, 360)) -> None:
+    def __init__(self, resolution: tuple[int, int] = (640, 360), max_batch_size: int = 30) -> None:
         self.resolution = resolution
+        self.max_batch_size = max_batch_size
 
     def extract_images(self, frames: Iterable[Frame], outdir: Path) -> Sequence[Sequence[Path]]:
         outdir.mkdir(parents=True, exist_ok=True)
 
         current_batch: list[Path] = []
+        all_batches: list[list[Path]] = []
 
         for frame in frames:
             if not frame.filter_keep:
@@ -161,7 +163,14 @@ class RescaledFrameImageExtractor(FrameImageExtractor):
             cv2.imwrite(str(image_path), rescaled_image)
             current_batch.append(image_path)
 
-        return [current_batch] if current_batch else []
+            if len(current_batch) >= self.max_batch_size:
+                all_batches.append(current_batch)
+                current_batch = []
+
+        if current_batch:
+            all_batches.append(current_batch)
+
+        return all_batches
 
 
 T = TypeVar("T", bound=BaseModel)

--- a/src/wildcamtools/lib/ai/pipeline_config.py
+++ b/src/wildcamtools/lib/ai/pipeline_config.py
@@ -102,6 +102,10 @@ class FrameExtractorConfig(BaseModel):
         tuple[Annotated[int, Field(strict=True, gt=0)], Annotated[int, Field(strict=True, gt=0)]],
         Field(description="Target resolution as (width, height)"),
     ] = (640, 360)
+    max_batch_size: Annotated[
+        int,
+        Field(strict=True, gt=0, description="Maximum number of images per batch"),
+    ] = 30
 
     def create_frame_extractor(self) -> RescaledFrameImageExtractor:
         """Create a FrameImageExtractor instance based on the configuration.
@@ -109,7 +113,7 @@ class FrameExtractorConfig(BaseModel):
         Returns:
             RescaledFrameImageExtractor: The configured frame extractor instance.
         """
-        return RescaledFrameImageExtractor(resolution=self.resolution)
+        return RescaledFrameImageExtractor(resolution=self.resolution, max_batch_size=self.max_batch_size)
 
 
 class LlmConfig(BaseModel):

--- a/tests/lib/ai/test_pipeline.py
+++ b/tests/lib/ai/test_pipeline.py
@@ -579,6 +579,66 @@ class TestRescaledFrameImageExtractor:
         assert len(result[0]) == len(sample_frames)
         assert all(isinstance(p, Path) for p in result[0])
 
+    def test_rescaled_extractor_max_batch_size(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test max_batch_size splits batches correctly."""
+        frames = []
+        for i in range(75):
+            raw = np.zeros((100, 200, 3), dtype=np.uint8)
+            raw[:, :] = [(i * 10) % 256, (i * 20) % 256, (i * 30) % 256]
+            frame = Frame(raw=raw, frame_no=i, filter_keep=True)
+            frames.append(frame)
+        extractor = RescaledFrameImageExtractor(max_batch_size=30)
+        result = extractor.extract_images(frames, tmp_path)
+
+        assert len(result) == 3
+        assert len(result[0]) == 30
+        assert len(result[1]) == 30
+        assert len(result[2]) == 15
+
+    def test_rescaled_extractor_max_batch_size_default(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test default max_batch_size is 30."""
+        extractor = RescaledFrameImageExtractor()
+        assert extractor.max_batch_size == 30
+
+    def test_rescaled_extractor_max_batch_size_custom(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test custom max_batch_size is stored."""
+        extractor = RescaledFrameImageExtractor(max_batch_size=50)
+        assert extractor.max_batch_size == 50
+
+    def test_rescaled_extractor_max_batch_size_exact_multiple(
+        self,
+        sample_frames: list[Frame],
+        tmp_path: Path,
+    ) -> None:
+        """Test when frames exactly match batch size."""
+        extractor = RescaledFrameImageExtractor(max_batch_size=len(sample_frames))
+        result = extractor.extract_images(sample_frames, tmp_path)
+
+        assert len(result) == 1
+        assert len(result[0]) == len(sample_frames)
+
+    def test_rescaled_extractor_max_batch_size_one(
+        self,
+        sample_frames: list[Frame],
+        tmp_path: Path,
+    ) -> None:
+        """Test max_batch_size=1 creates one batch per frame."""
+        extractor = RescaledFrameImageExtractor(max_batch_size=1)
+        result = extractor.extract_images(sample_frames, tmp_path)
+
+        assert len(result) == len(sample_frames)
+        for batch in result:
+            assert len(batch) == 1
+
     def test_extract_images_with_empty_frames(self, tmp_path: Path) -> None:
         """Test edge case with empty frame list."""
         extractor = RescaledFrameImageExtractor()

--- a/tests/lib/ai/test_pipeline_config.py
+++ b/tests/lib/ai/test_pipeline_config.py
@@ -255,10 +255,20 @@ class TestFrameExtractorConfig:
     def test_default_values(self) -> None:
         config = FrameExtractorConfig()
         assert config.resolution == (640, 360)
+        assert config.max_batch_size == 30
 
     def test_custom_resolution(self) -> None:
         config = FrameExtractorConfig(resolution=(1280, 720))
         assert config.resolution == (1280, 720)
+
+    def test_custom_max_batch_size(self) -> None:
+        config = FrameExtractorConfig(max_batch_size=50)
+        assert config.max_batch_size == 50
+
+    def test_custom_resolution_and_max_batch_size(self) -> None:
+        config = FrameExtractorConfig(resolution=(1280, 720), max_batch_size=25)
+        assert config.resolution == (1280, 720)
+        assert config.max_batch_size == 25
 
     def test_invalid_resolution_zero_width(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
@@ -275,14 +285,35 @@ class TestFrameExtractorConfig:
             FrameExtractorConfig(resolution=(-100, 200))
         assert "gt=0" in str(exc_info.value) or "greater than 0" in str(exc_info.value).lower()
 
+    def test_invalid_max_batch_size_zero(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            FrameExtractorConfig(max_batch_size=0)
+        assert "gt=0" in str(exc_info.value) or "greater than 0" in str(exc_info.value).lower()
+
+    def test_invalid_max_batch_size_negative(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            FrameExtractorConfig(max_batch_size=-10)
+        assert "gt=0" in str(exc_info.value) or "greater than 0" in str(exc_info.value).lower()
+
     def test_create_frame_extractor(self) -> None:
         config = FrameExtractorConfig(resolution=(800, 600))
         extractor = config.create_frame_extractor()
         assert extractor.resolution == (800, 600)
+        assert extractor.max_batch_size == 30
+
+    def test_create_frame_extractor_with_custom_max_batch_size(self) -> None:
+        config = FrameExtractorConfig(resolution=(800, 600), max_batch_size=50)
+        extractor = config.create_frame_extractor()
+        assert extractor.resolution == (800, 600)
+        assert extractor.max_batch_size == 50
 
     def test_strict_type_validation_resolution(self) -> None:
         with pytest.raises(ValidationError):
             FrameExtractorConfig(resolution=("640", "360"))
+
+    def test_strict_type_validation_max_batch_size(self) -> None:
+        with pytest.raises(ValidationError):
+            FrameExtractorConfig(max_batch_size="30")
 
 
 class TestLlmConfig:


### PR DESCRIPTION
Introduces a `max_batch_size` limit to the `RescaledFrameImageExtractor` to prevent excessively large batches of images from being processed at once.

Key changes:
- Added `max_batch_size` to `RescaledFrameImageExtractor` (default: 30).
- Updated `FrameExtractorConfig` to support and validate `max_batch_size`.
- Modified `extract_images` to yield multiple batches when the number of frames exceeds the limit.
- Added comprehensive tests for batch splitting, default values, and validation.