### PR TITLE
Remove generic to simplify results

### DIFF
--- a/pipelines/pipeline_config.json
+++ b/pipelines/pipeline_config.json
@@ -17,8 +17,7 @@
   },
   "query": {
     "query_type": "llm",
-    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult"
+    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/pipeline_config_5x1280x720.json
+++ b/pipelines/pipeline_config_5x1280x720.json
@@ -17,8 +17,7 @@
   },
   "query": {
     "query_type": "llm",
-    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult"
+    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/pipeline_config_crop.json
+++ b/pipelines/pipeline_config_crop.json
@@ -23,8 +23,7 @@
   },
   "query": {
     "query_type": "llm",
-    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult"
+    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/pipeline_config_motion.json
+++ b/pipelines/pipeline_config_motion.json
@@ -17,8 +17,7 @@
   },
   "query": {
     "query_type": "llm",
-    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult"
+    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/pipeline_config_prompt.json
+++ b/pipelines/pipeline_config_prompt.json
@@ -17,8 +17,7 @@
   },
   "query": {
     "query_type": "llm",
-    "prompt": "Analyze this frame from a UK garden surveillance camera located near a river. Your goal is to identify animals with high precision, prioritizing the avoidance of false positives.\nStep 1: Visual Analysis Describe the specific visual evidence of an animal. Identify the shape, color, and distinct anatomical features (e.g., ears, tail, legs) that suggest a living creature is present. If you only see ambiguous shapes, shadows, or foliage, state 'No'\nStep 2: Skeptical Verification Consider if the identified shape could be a non-animal object (e.g., a rock, a garden ornament, a leaf, or a lighting artifact). If there is any significant ambiguity, default to 'no'.\nStep 3: Final Identification If and only if you are confident an animal is present",
-    "response_schema": "SpeciesResult"
+    "prompt": "Analyze this frame from a UK garden surveillance camera located near a river. Your goal is to identify animals with high precision, prioritizing the avoidance of false positives.\nStep 1: Visual Analysis Describe the specific visual evidence of an animal. Identify the shape, color, and distinct anatomical features (e.g., ears, tail, legs) that suggest a living creature is present. If you only see ambiguous shapes, shadows, or foliage, state 'No'\nStep 2: Skeptical Verification Consider if the identified shape could be a non-animal object (e.g., a rock, a garden ornament, a leaf, or a lighting artifact). If there is any significant ambiguity, default to 'no'.\nStep 3: Final Identification If and only if you are confident an animal is present"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/pipeline_config_ssim.json
+++ b/pipelines/pipeline_config_ssim.json
@@ -22,8 +22,7 @@
   },
   "query": {
     "query_type": "llm",
-    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult"
+    "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?"
   },
   "reconciler": {
     "reconciler_type": "majority"

--- a/pipelines/pipeline_config_verify_high.json
+++ b/pipelines/pipeline_config_verify_high.json
@@ -18,7 +18,6 @@
   "query": {
     "query_type": "verified",
     "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult",
     "min_confidence": "high"
   },
   "reconciler": {

--- a/pipelines/pipeline_config_verify_med.json
+++ b/pipelines/pipeline_config_verify_med.json
@@ -18,7 +18,6 @@
   "query": {
     "query_type": "verified",
     "prompt": "This is a video image from a UK garden near a river. Is there an animal in this image, if so what?",
-    "response_schema": "SpeciesResult",
     "min_confidence": "medium"
   },
   "reconciler": {

--- a/pipelines/run.sh
+++ b/pipelines/run.sh
@@ -6,11 +6,11 @@ set -a && source pipelines/.env && set +a
 uv run wildcamtools ai run-evaluate --help
 
 
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_prompt.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/prompt.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_verify_high.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_high.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_verify_med.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_med.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_motion.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/motion.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config_ssim.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/ssim.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config.json pipelines/comparison_config_crop.json wildlife/2023/labels.jsonl --output pipelines/output/crop.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/output.json
-uv run wildcamtools ai run-evaluate pipelines/pipeline_config.json pipelines/comparison_config_5x1280x720.json wildlife/2023/labels.jsonl --output pipelines/output/5x1280x720.json
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_prompt.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/prompt.json 2>&1 | tee pipelines/output/output_prompt.log
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_verify_high.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_high.json 2>&1 | tee pipelines/output/output_verify_high.log
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_verify_med.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/verify_med.json 2>&1 | tee pipelines/output/output_verify_med.log
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_motion.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/motion.json 2>&1 | tee pipelines/output/output_motion.log
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_ssim.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/ssim.json 2>&1 | tee pipelines/output/output_ssim.log
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_crop.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/crop.json 2>&1 | tee pipelines/output/output_crop.log
+uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/output.json 2>&1 | tee pipelines/output/output.log
+#uv run wildcamtools ai run-evaluate -w 4 pipelines/pipeline_config_5x1280x720.json pipelines/comparison_config.json wildlife/2023/labels.jsonl --output pipelines/output/5x1280x720.json 2>&1 | tee pipelines/output/output_5x1280x720.log

--- a/src/wildcamtools/lib/ai/__init__.py
+++ b/src/wildcamtools/lib/ai/__init__.py
@@ -26,7 +26,6 @@ from wildcamtools.lib.ai.pipeline_config import (
     LlmConfig,
     ReconcilerConfig,
     ReconcilerType,
-    ResponseSchemaType,
 )
 from wildcamtools.lib.ai.pipeline_evaluation import (
     PipelineEvaluationResult,
@@ -40,8 +39,7 @@ from wildcamtools.lib.ai.types import (
     Result,
     ResultClassification,
     ResultList,
-    SpeciesResult,
-    StringResponse,
+    RichResult,
 )
 
 __all__ = [
@@ -72,14 +70,12 @@ __all__ = [
     "ReconcilerConfig",
     "ReconcilerType",
     "RescaledFrameImageExtractor",
-    "ResponseSchemaType",
     "Result",
     "ResultClassification",
     "ResultList",
     "ResultReconciler",
+    "RichResult",
     "SSIMFrameSelector",
-    "SpeciesResult",
-    "StringResponse",
     "VerifiedImageBatchQuery",
     "evaluate_ai_pipeline",
 ]

--- a/src/wildcamtools/lib/ai/label_comparison.py
+++ b/src/wildcamtools/lib/ai/label_comparison.py
@@ -2,19 +2,24 @@ import logging
 from abc import ABC, abstractmethod
 
 from wildcamtools.lib.ai.llm.abstract import AbstractLlm
-from wildcamtools.lib.ai.types import BoolResponse, ResultClassification
+from wildcamtools.lib.ai.pipeline import CONFIDENCE_ORDER
+from wildcamtools.lib.ai.types import (
+    ABSENCE_MARKERS,
+    UNKNOWN_MARKERS,
+    BoolResponse,
+    ConfidenceLevel,
+    ResultClassification,
+    RichResult,
+)
 
 logger = logging.getLogger(__name__)
-
-ABSENCE_MARKERS = {"", "none", "no animal", "missing", "empty", "no", "no detection"}
-UNKNOWN_MARKERS = {"unknown", "uncertain", "unsure"}
 
 
 class AbstractLabelComparator(ABC):
     """Abstract base class for label comparison strategies."""
 
     @staticmethod
-    def _check_special_cases(result: str, label: str) -> tuple[bool, ResultClassification] | None:
+    def _check_special_cases(result: str, label: str) -> ResultClassification | None:
         """Check for special cases (unknown markers, absence markers).
 
         Args:
@@ -22,38 +27,36 @@ class AbstractLabelComparator(ABC):
             label: The ground truth label.
 
         Returns:
-            Tuple of (is_correct, classification) if a special case is detected,
-            None otherwise.
+            Classification if a special case is detected, None otherwise.
         """
         result_lower = result.lower()
         label_lower = label.lower()
 
         if result_lower in UNKNOWN_MARKERS:
-            return False, ResultClassification.UNKNOWN
+            return ResultClassification.UNKNOWN
 
         if result_lower in ABSENCE_MARKERS:
             if label_lower in ABSENCE_MARKERS:
-                return True, ResultClassification.CORRECT
+                return ResultClassification.CORRECT
             else:
-                return False, ResultClassification.INCORRECT
+                return ResultClassification.INCORRECT
 
         if result_lower == label_lower:
-            return True, ResultClassification.CORRECT
+            return ResultClassification.CORRECT
 
         return None
 
     @abstractmethod
-    def compare(self, result: str, label: str) -> tuple[bool, ResultClassification]:
+    def compare(self, result: RichResult, label: str) -> ResultClassification:
         """Compare a pipeline result against a ground truth label.
 
         Args:
-            result: The raw result string from the pipeline.
+            result: The result from the pipeline.
             label: The ground truth label.
 
         Returns:
-            Tuple of (is_correct, classification) where:
-            - is_correct: True if the result matches the label
-            - classification: The type of result (correct, incorrect, unknown)
+            The classification type (correct, incorrect, unknown).
+            The correctness can be inferred from the classification value.
         """
         ...
 
@@ -67,12 +70,25 @@ class AbstractLabelComparator(ABC):
 class ExactLabelComparator(AbstractLabelComparator):
     """Exact string matching comparator (case-insensitive)."""
 
-    def compare(self, result: str, label: str) -> tuple[bool, ResultClassification]:
-        special_case = self._check_special_cases(result, label)
+    def compare(self, result: RichResult, label: str) -> ResultClassification:
+        if result.is_animal_unknown:
+            return ResultClassification.UNKNOWN
+
+        if CONFIDENCE_ORDER[result.confidence] < CONFIDENCE_ORDER[ConfidenceLevel.HIGH]:
+            return ResultClassification.UNKNOWN
+
+        if not result.is_animal_present:
+            if label.lower() in ABSENCE_MARKERS:
+                return ResultClassification.CORRECT
+            else:
+                return ResultClassification.INCORRECT
+
+        special_case = self._check_special_cases(result.species_name, label)
         if special_case is not None:
             return special_case
 
-        return False, ResultClassification.INCORRECT
+        # only get here if its not an exact match
+        return ResultClassification.INCORRECT
 
     @property
     def method_name(self) -> str:
@@ -91,7 +107,7 @@ class LLMLabelComparator(AbstractLabelComparator):
         - "animal" vs "cat" → False (too general)
     """
 
-    _cache: dict[tuple[str, str], tuple[bool, ResultClassification]] | None
+    _cache: dict[tuple[str, str], ResultClassification] | None
 
     def __init__(
         self,
@@ -110,28 +126,39 @@ class LLMLabelComparator(AbstractLabelComparator):
             "- If result is a different category, answer False\n"
             "- If both result and label is missing, empty, or contains only 'none', 'no', answer True\n"
             "\n"
-            "result is '{result}'"
+            "result is '{result}'\n"
             "label is '{label}'"
         )
         self._cache = {} if cache_enabled else None
 
-    def compare(self, result: str, label: str) -> tuple[bool, ResultClassification]:
-        special_case = self._check_special_cases(result, label)
+    def compare(self, result: RichResult, label: str) -> ResultClassification:
+        result_lower = result.species_name.lower()
+        label_lower = label.lower()
+
+        if result.is_animal_unknown:
+            return ResultClassification.UNKNOWN
+
+        if CONFIDENCE_ORDER[result.confidence] < CONFIDENCE_ORDER[ConfidenceLevel.HIGH]:
+            return ResultClassification.UNKNOWN
+
+        if not result.is_animal_present:
+            if label_lower in ABSENCE_MARKERS:
+                return ResultClassification.CORRECT
+            else:
+                return ResultClassification.INCORRECT
+
+        special_case = self._check_special_cases(result_lower, label_lower)
         if special_case is not None:
             return special_case
-
-        result_lower = result.lower()
-        label_lower = label.lower()
 
         if self._cache is not None:
             cache_key = (result_lower, label_lower)
             if cache_key in self._cache:
-                logger.debug("Using cached comparison for (%s, %s)", result, label)
-                is_correct, classification = self._cache[cache_key]
-                return is_correct, classification
+                logger.debug("Using cached comparison for (%s, %s)", result.species_name, label)
+                return self._cache[cache_key]
 
-        message = self.prompt.format(result=result, label=label)
-        logger.debug("Comparing '%s' vs '%s' using LLM", result, label)
+        message = self.prompt.format(result=result.species_name, label=label)
+        logger.debug("Comparing '%s' vs '%s' using LLM", result.species_name, label)
 
         response = self.llm.message_with_schema(
             message=message,
@@ -142,9 +169,9 @@ class LLMLabelComparator(AbstractLabelComparator):
         classification = ResultClassification.CORRECT if response.answer else ResultClassification.INCORRECT
 
         if self._cache is not None:
-            self._cache[cache_key] = (response.answer, classification)
-        logger.info("Comparison result: '%s' vs '%s' = %s", result, label, response.answer)
-        return response.answer, classification
+            self._cache[cache_key] = classification
+        logger.info("Comparison result: '%s' vs '%s' = %s", result.species_name, label, response.answer)
+        return classification
 
     @property
     def method_name(self) -> str:

--- a/src/wildcamtools/lib/ai/llm/abstract.py
+++ b/src/wildcamtools/lib/ai/llm/abstract.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 
 from pydantic import BaseModel
 
-from wildcamtools.lib.ai.types import Backend, StringResponse
+from wildcamtools.lib.ai.types import Backend, RichResult
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -30,7 +30,7 @@ class AbstractLlm(abc.ABC):
         message: str,
         images: Sequence[Path] = (),
         # mypy limitation with generic type defaults
-        response_class: type[T] = StringResponse,  # type: ignore[assignment]
+        response_class: type[T] = RichResult,  # type: ignore[assignment]
     ) -> T: ...
 
     @staticmethod

--- a/src/wildcamtools/lib/ai/llm/llamacpp.py
+++ b/src/wildcamtools/lib/ai/llm/llamacpp.py
@@ -7,7 +7,7 @@ import openai as openai_lib
 from pydantic import ValidationError
 
 from wildcamtools.lib.ai.llm.abstract import DEFAULT_SYSTEM_MESSAGE, AbstractLlm, T
-from wildcamtools.lib.ai.types import Backend, StringResponse
+from wildcamtools.lib.ai.types import Backend, RichResult
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class LlamaCppLlm(AbstractLlm):
         message: str,
         images: Sequence[Path] = (),
         # mypy limitation with generic type defaults
-        response_class: type[T] = StringResponse,  # type: ignore[assignment]
+        response_class: type[T] = RichResult,  # type: ignore[assignment]
     ) -> T:
         image_bytes = [self.path_jpeg_to_base64(image) for image in images]
         logger.info("Loaded %d images for message", len(image_bytes))

--- a/src/wildcamtools/lib/ai/llm/ollama.py
+++ b/src/wildcamtools/lib/ai/llm/ollama.py
@@ -7,7 +7,7 @@ import ollama as ollama_lib
 from pydantic import ValidationError
 
 from wildcamtools.lib.ai.llm.abstract import DEFAULT_SYSTEM_MESSAGE, AbstractLlm, T
-from wildcamtools.lib.ai.types import Backend, StringResponse
+from wildcamtools.lib.ai.types import Backend, RichResult
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class OllamaLlm(AbstractLlm):
         message: str,
         images: Sequence[Path] = (),
         # mypy limitation with generic type defaults
-        response_class: type[T] = StringResponse,  # type: ignore[assignment]
+        response_class: type[T] = RichResult,  # type: ignore[assignment]
     ) -> T:
         image_bytes = [image.read_bytes() for image in images]
         logger.info("Loaded %d images for message", len(image_bytes))

--- a/src/wildcamtools/lib/ai/pipeline.py
+++ b/src/wildcamtools/lib/ai/pipeline.py
@@ -4,15 +4,18 @@ import tempfile
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
-from typing import TypeVar
 
 import cv2
-from pydantic import BaseModel
 
 from wildcamtools.lib import Frame
 from wildcamtools.lib.ai.crop import AICropFinder
 from wildcamtools.lib.ai.llm.abstract import AbstractLlm
-from wildcamtools.lib.ai.types import ConfidenceLevel, ResultList, VerificationResult
+from wildcamtools.lib.ai.types import (
+    ConfidenceLevel,
+    ResultList,
+    RichResult,
+    VerificationResult,
+)
 from wildcamtools.lib.frames import FilterSSIM, Rescaler, resize_with_aspect_ratio
 from wildcamtools.lib.motion import MogMotion
 from wildcamtools.lib.stats import get_video_stats
@@ -239,52 +242,45 @@ Return results as a ResultList with species_name and frames array."""
         return output_batches
 
 
-T = TypeVar("T", bound=BaseModel)
-
-
-class ImageBatchQuery[T](ABC):
-    def query_image_batches(self, image_batches: Iterable[Iterable[Path]]) -> Iterator[T]:
+class ImageBatchQuery(ABC):
+    def query_image_batches(self, image_batches: Iterable[Iterable[Path]]) -> Iterator[RichResult]:
         for batch in image_batches:
             yield self.query_images(list(batch))
 
     @abstractmethod
-    def query_images(self, images: Sequence[Path]) -> T: ...
+    def query_images(self, images: Sequence[Path]) -> RichResult: ...
 
 
-class LlmImageBatchQuery[T](ImageBatchQuery[T]):
+class LlmImageBatchQuery(ImageBatchQuery):
     llm: AbstractLlm
     prompt: str
-    response_class: type[T]
 
     def __init__(
         self,
         llm: AbstractLlm,
         prompt: str,
-        response_class: type[T],
     ) -> None:
         self.llm = llm
         self.prompt = prompt
-        self.response_class = response_class
 
-    def query_images(self, images: Sequence[Path]) -> T:
+    def query_images(self, images: Sequence[Path]) -> RichResult:
         images_list = sorted(images)
         if not images_list:
             logger.warning("Empty image batch received")
             raise ValueError("Empty image batch")
         logger.info("Sending %d images to analyser", len(images_list))
-        result: T = self.llm.message_with_schema(
+        result: RichResult = self.llm.message_with_schema(
             message=self.prompt,
             images=images_list,
-            response_class=self.response_class,
-        )  # type: ignore[type-var]
+            response_class=RichResult,
+        )
         logger.info("Received response from analyser")
         return result
 
 
-class VerifiedImageBatchQuery(ImageBatchQuery[VerificationResult]):
+class VerifiedImageBatchQuery(ImageBatchQuery):
     llm: AbstractLlm
     prompt: str
-    response_class: type[BaseModel]
     verification_prompt: str
     min_confidence: ConfidenceLevel
 
@@ -292,67 +288,59 @@ class VerifiedImageBatchQuery(ImageBatchQuery[VerificationResult]):
         self,
         llm: AbstractLlm,
         prompt: str,
-        response_class: type[BaseModel],
         verification_prompt: str | None = None,
         min_confidence: ConfidenceLevel = ConfidenceLevel.MEDIUM,
     ) -> None:
         self.llm = llm
         self.prompt = prompt
-        self.response_class = response_class
         self.verification_prompt = verification_prompt or DEFAULT_VERIFICATION_PROMPT
         self.min_confidence = min_confidence
 
-    def query_images(self, images: Sequence[Path]) -> VerificationResult:
+    def query_images(self, images: Sequence[Path]) -> RichResult:
         images_list = sorted(images)
         if not images_list:
             logger.warning("Empty image batch received")
             raise ValueError("Empty image batch")
 
         logger.debug("Sending %d images to analyser for initial classification", len(images_list))
-        initial_result = self.llm.message_with_schema(
+        initial_result: RichResult = self.llm.message_with_schema(
             message=self.prompt,
             images=images_list,
-            response_class=self.response_class,
+            response_class=RichResult,
         )
+        logger.debug("Initial classification: %s", initial_result.species_name)
 
-        initial_species = getattr(initial_result, "species_name", str(initial_result))
-        logger.debug("Initial classification: %s", initial_species)
-
-        verification_message = self.verification_prompt.format(initial_species=initial_species)
-        logger.debug("Verifying classification with confidence check")
+        verification_message = self.verification_prompt.format(initial_species=initial_result.species_name)
         verification_result: VerificationResult = self.llm.message_with_schema(
             message=verification_message,
             images=images_list,
             response_class=VerificationResult,
         )
 
-        if not self._meets_confidence_threshold(verification_result.confidence) or not verification_result.verified:
+        # update confidence and species name from verification
+        initial_result.confidence = verification_result.confidence
+        initial_result.species_name = verification_result.species_name
+
+        if not verification_result.verified or not self._meets_confidence_threshold(verification_result.confidence):
             logger.debug(
-                "Confidence %s below threshold %s or verified=%s, marking as unknown",
+                "Verification failed or confidence %s below threshold %s, marking as unknown",
                 verification_result.confidence,
                 self.min_confidence,
-                verification_result.verified,
             )
-            verification_result = verification_result.model_copy(update={"species_name": "unknown", "verified": False})
+            initial_result.is_animal_unknown = True
 
-        logger.info(
-            "Verification complete: species=%s, confidence=%s, verified=%s",
-            verification_result.species_name,
-            verification_result.confidence,
-            verification_result.verified,
-        )
-        return verification_result
+        return initial_result
 
     def _meets_confidence_threshold(self, confidence: ConfidenceLevel) -> bool:
         return CONFIDENCE_ORDER[confidence] >= CONFIDENCE_ORDER[self.min_confidence]
 
 
-class ResultReconciler[T](ABC):
+class ResultReconciler(ABC):
     @abstractmethod
-    def reconcile_results(self, results: Iterable[T]) -> T: ...
+    def reconcile_results(self, results: Iterable[RichResult]) -> RichResult: ...
 
 
-class MajorityResultReconciler[T](ResultReconciler[T]):
+class MajorityResultReconciler(ResultReconciler):
     """Reconciles multiple results by selecting the most common value.
 
     Uses equality comparison (__eq__) to determine uniqueness.
@@ -362,7 +350,7 @@ class MajorityResultReconciler[T](ResultReconciler[T]):
         ValueError: If results iterable is empty.
     """
 
-    def reconcile_results(self, results: Iterable[T]) -> T:
+    def reconcile_results(self, results: Iterable[RichResult]) -> RichResult:
         results_list = list(results)
         if not results_list:
             raise ValueError("No results to reconcile")
@@ -370,7 +358,7 @@ class MajorityResultReconciler[T](ResultReconciler[T]):
             return results_list[0]
 
         logger.debug("Reconciling %d results", len(results_list))
-        seen_order: list[T] = []
+        seen_order: list[RichResult] = []
         counts: list[int] = []
 
         for result in results_list:
@@ -395,25 +383,25 @@ class MajorityResultReconciler[T](ResultReconciler[T]):
         raise RuntimeError("Unable to reconcile results")  # pragma: no cover
 
 
-class AiPipeline[T](ABC):
+class AiPipeline(ABC):
     frame_selector: FrameSelector
     frame_image_extractor: FrameImageExtractor
-    image_batch_query: ImageBatchQuery[T]
-    result_reconciler: ResultReconciler[T]
+    image_batch_query: ImageBatchQuery
+    result_reconciler: ResultReconciler
 
     def __init__(
         self,
         frame_selector: FrameSelector,
         frame_image_extractor: FrameImageExtractor,
-        image_batch_query: ImageBatchQuery[T],
-        result_reconciler: ResultReconciler[T],
+        image_batch_query: ImageBatchQuery,
+        result_reconciler: ResultReconciler,
     ) -> None:
         self.frame_selector = frame_selector
         self.frame_image_extractor = frame_image_extractor
         self.image_batch_query = image_batch_query
         self.result_reconciler = result_reconciler
 
-    def run(self, video: Path) -> T:
+    def run(self, video: Path) -> RichResult:
         # select frames from the video
         # e.g. fps, similarity
         frames = self.frame_selector.select_frames(video)

--- a/src/wildcamtools/lib/ai/pipeline_config.py
+++ b/src/wildcamtools/lib/ai/pipeline_config.py
@@ -23,7 +23,7 @@ from wildcamtools.lib.ai.pipeline import (
     SSIMFrameSelector,
     VerifiedImageBatchQuery,
 )
-from wildcamtools.lib.ai.types import Backend, ConfidenceLevel, Result, SpeciesResult, StringResponse
+from wildcamtools.lib.ai.types import Backend, ConfidenceLevel
 
 
 class FrameSelectorType(StrEnum):
@@ -41,22 +41,9 @@ class ReconcilerType(StrEnum):
     MAJORITY = "majority"
 
 
-class ResponseSchemaType(StrEnum):
-    SPECIES_RESULT = "SpeciesResult"
-    RESULT = "Result"
-    STRING_RESPONSE = "StringResponse"
-
-
 class ImageBatchQueryType(StrEnum):
     LLM = "llm"
     VERIFIED = "verified"
-
-
-RESPONSE_SCHEMA_MAP: dict[ResponseSchemaType, type[BaseModel]] = {
-    ResponseSchemaType.SPECIES_RESULT: SpeciesResult,
-    ResponseSchemaType.RESULT: Result,
-    ResponseSchemaType.STRING_RESPONSE: StringResponse,
-}
 
 
 class FrameSelectorConfig(BaseModel):
@@ -199,7 +186,6 @@ class LlmConfig(BaseModel):
 class ImageBatchQueryConfig(BaseModel):
     query_type: ImageBatchQueryType = ImageBatchQueryType.LLM
     prompt: Annotated[str, Field(strict=True, min_length=1, description="Prompt sent to LLM")]
-    response_schema: ResponseSchemaType = ResponseSchemaType.SPECIES_RESULT
     verification_prompt: Annotated[
         str | None,
         Field(
@@ -209,14 +195,6 @@ class ImageBatchQueryConfig(BaseModel):
     ] = None
     min_confidence: ConfidenceLevel = ConfidenceLevel.MEDIUM
 
-    def get_response_class(self) -> type[BaseModel]:
-        """Get the Pydantic model class for the response schema.
-
-        Returns:
-            type[BaseModel]: The Pydantic model class corresponding to response_schema.
-        """
-        return RESPONSE_SCHEMA_MAP[self.response_schema]
-
     def create_image_batch_query(self, llm: AbstractLlm) -> ImageBatchQuery:
         """Create an ImageBatchQuery instance based on the configuration.
 
@@ -225,20 +203,15 @@ class ImageBatchQueryConfig(BaseModel):
 
         Returns:
             ImageBatchQuery: The configured image batch query instance (LlmImageBatchQuery or VerifiedImageBatchQuery).
+            Both return RichResult.
         """
-        response_class = self.get_response_class()
         match self.query_type:
             case ImageBatchQueryType.LLM:
-                return LlmImageBatchQuery(
-                    llm=llm,
-                    prompt=self.prompt,
-                    response_class=response_class,
-                )
+                return LlmImageBatchQuery(llm=llm, prompt=self.prompt)
             case ImageBatchQueryType.VERIFIED:
                 return VerifiedImageBatchQuery(
                     llm=llm,
                     prompt=self.prompt,
-                    response_class=response_class,
                     verification_prompt=self.verification_prompt,
                     min_confidence=self.min_confidence,
                 )
@@ -253,7 +226,7 @@ class ReconcilerConfig(BaseModel):
         """Create a ResultReconciler instance based on the configuration.
 
         Returns:
-            ResultReconciler: The configured reconciler instance.
+            ResultReconciler: The configured reconciler instance (returns RichResult).
 
         Raises:
             NotImplementedError: If the reconciler_type is not supported.

--- a/src/wildcamtools/lib/ai/pipeline_evaluation.py
+++ b/src/wildcamtools/lib/ai/pipeline_evaluation.py
@@ -10,7 +10,7 @@ from wildcamtools.lib import Frame
 from wildcamtools.lib.ai.label_comparison_config import LabelComparisonConfig
 from wildcamtools.lib.ai.pipeline import FrameSelector
 from wildcamtools.lib.ai.pipeline_config import AiPipelineConfig
-from wildcamtools.lib.ai.types import ResultClassification, SpeciesResult
+from wildcamtools.lib.ai.types import ResultClassification, RichResult
 from wildcamtools.lib.labels import load_labels
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class _WorkerResult(BaseModel):
     """Result from worker process before label comparison."""
 
     filename: str
-    raw_result: str
+    result: RichResult
     processing_time_seconds: float = 0.0
     frame_ids: list[int] = Field(default_factory=list)
     error: str | None = None
@@ -46,17 +46,12 @@ class _WorkerResult(BaseModel):
 class PipelineEvaluationResult(BaseModel):
     filename: str
     classification: ResultClassification
-    raw_result: str
+    result: RichResult
     label: str
     error: str | None = None
     comparison_method: str = "exact"
     processing_time_seconds: float = 0.0
     frame_ids: list[int] = Field(default_factory=list)
-    is_correct: bool = False
-
-    @property
-    def correct(self) -> bool:
-        return self.is_correct
 
 
 class PipelineEvaluationSummary(BaseModel):
@@ -127,23 +122,16 @@ def _evaluate_video_worker(
         processing_time = end_time - start_time
         frame_ids = wrapper.frame_ids
 
-        if isinstance(result, SpeciesResult) or hasattr(result, "species_name"):
-            raw_result = result.species_name
-        elif hasattr(result, "message"):
-            raw_result = result.message
-        else:
-            raw_result = str(result)
-
         logger.info(
             "Video %s: result=%s, frames=%s",
             video_path.name,
-            raw_result,
+            result.species_name,
             frame_ids,
         )
 
         return _WorkerResult(
             filename=video_path.name,
-            raw_result=raw_result,
+            result=result,
             processing_time_seconds=processing_time,
             frame_ids=frame_ids,
             error=None,
@@ -194,22 +182,24 @@ def _run_worker_pool(
 
         for label, future in futures:
             try:
-                worker_result = future.get()
+                worker_result: _WorkerResult = future.get()
             except Exception:
                 logger.exception("Worker task failed")
                 continue
-            is_correct, classification = comparator.compare(worker_result.raw_result, label)
+            if not isinstance(worker_result, _WorkerResult):
+                logger.error("Result of unexpected class")
+                continue
+            classification = comparator.compare(worker_result.result, label)
             results.append(
                 PipelineEvaluationResult(
                     filename=worker_result.filename,
+                    result=worker_result.result,
                     classification=classification,
-                    raw_result=worker_result.raw_result,
                     label=label,
                     error=worker_result.error,
                     comparison_method=comparator.method_name,
                     processing_time_seconds=worker_result.processing_time_seconds,
                     frame_ids=worker_result.frame_ids,
-                    is_correct=is_correct,
                 )
             )
 

--- a/src/wildcamtools/lib/ai/types.py
+++ b/src/wildcamtools/lib/ai/types.py
@@ -3,6 +3,9 @@ from typing import Annotated
 
 from pydantic import BaseModel, Field
 
+ABSENCE_MARKERS = {"", "none", "no animal", "missing", "empty", "no", "no detection"}
+UNKNOWN_MARKERS = {"unknown", "uncertain", "unsure"}
+
 
 class Backend(StrEnum):
     LLAMACPP = "llamacpp"
@@ -37,29 +40,6 @@ class BoolResponse(BaseModel):
     ]
 
 
-class StringResponse(BaseModel):
-    message: Annotated[
-        str,
-        Field(
-            description="Text response that can express uncertainty. Use 'unknown' when you cannot confidently "
-            "identify something, 'no animal' when nothing is present, or provide a specific identification.",
-            examples=["unknown", "no animal", "European Badger"],
-        ),
-    ]
-
-
-class SpeciesResult(BaseModel):
-    species_name: Annotated[
-        str,
-        Field(
-            description="Identified wildlife species from camera trap images. Return a specific species name when "
-            "confident (e.g., 'European Badger', 'Red Fox', 'Wood Pigeon'). Return 'unknown' when you cannot "
-            "confidently identify the species. Return 'no animal' when no animal is present in the image.",
-            examples=["European Badger", "Red Fox", "unknown", "no animal"],
-        ),
-    ]
-
-
 class ConfidenceLevel(StrEnum):
     LOW = "low"
     MEDIUM = "medium"
@@ -86,9 +66,58 @@ class VerificationResult(BaseModel):
     verified: Annotated[
         bool,
         Field(
-            description="Whether you confirm the initial classification is correct. Set to false when the "
-            "classification is incorrect, when confidence is low, or when you cannot verify it.",
+            description="Whether the initial classification is verified as correct.",
             examples=[True, False],
+        ),
+    ]
+
+
+class RichResult(BaseModel):
+    is_animal_present: Annotated[
+        bool, Field(description="Flag if any animal is visible in these images.", examples=["true", "false"])
+    ]
+    is_animal_unknown: Annotated[
+        bool,
+        Field(
+            description="Flag if there is an animal visible in these images but you cannot identify what it is. "
+            "If no animal is visible, use 'false'. If an animal is visible and you can identify what species it is, "
+            "use 'false'. Use 'true' only if you are confident there is an animal visible and you are not confident "
+            "what species it is.",
+            examples=["true", "false"],
+        ),
+    ]
+
+    defining_features: Annotated[
+        str,
+        Field(
+            description="If there is an animal visible and you can confidently identify "
+            "what species it is, then the important features used for this identification should be described here. "
+            "Return 'unknown' when you cannot confidently identify the species. Return 'no animal' when no animal "
+            "is present in the image.",
+            examples=[
+                "short fur, pointy ears, long tail",
+                "small size, black feathers, yellow beak",
+                "unknown",
+                "no animal",
+            ],
+        ),
+    ]
+
+    species_name: Annotated[
+        str,
+        Field(
+            description="Identified wildlife species from camera trap images. Return a specific species name when "
+            "confident (e.g., 'European Badger', 'Red Fox', 'Wood Pigeon'). Return 'unknown' when you cannot "
+            "confidently identify the species. Return 'no animal' when no animal is present in the image.",
+            examples=["European Badger", "Red Fox", "unknown", "no animal"],
+        ),
+    ]
+    confidence: Annotated[
+        ConfidenceLevel,
+        Field(
+            description="Your confidence level in this result: 'high' for >80% confidence, "
+            "'medium' for 50-80% confidence with some uncertainty, 'low' for <50% confidence or significant doubts.",
+            examples=["high", "medium", "low"],
         ),
     ]
 
@@ -107,7 +136,6 @@ __all__ = [
     "Result",
     "ResultClassification",
     "ResultList",
-    "SpeciesResult",
-    "StringResponse",
+    "RichResult",
     "VerificationResult",
 ]

--- a/tests/cli/test_ai.py
+++ b/tests/cli/test_ai.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from wildcamtools.cli.ai import app as ai_app
 from wildcamtools.lib.ai import PipelineEvaluationResult, PipelineEvaluationSummary
-from wildcamtools.lib.ai.types import ResultClassification
+from wildcamtools.lib.ai.types import ConfidenceLevel, ResultClassification, RichResult
 
 runner = CliRunner()
 
@@ -222,7 +222,6 @@ class TestRunCommandIntegration:
             },
             "query": {
                 "prompt": "Custom prompt for testing",
-                "response_schema": "SpeciesResult",
             },
             "reconciler": {
                 "reconciler_type": "majority",
@@ -233,25 +232,6 @@ class TestRunCommandIntegration:
 
         result = runner.invoke(ai_app, ["run", "-c", str(config_file), str(sample_video_file)])
         assert result.exit_code != 0
-
-    def test_run_with_different_response_schemas(self, tmp_path: Path, sample_video_file: Path) -> None:
-        for schema in ["SpeciesResult", "Result", "StringResponse"]:
-            config = {
-                "llm": {
-                    "model": "test-model",
-                    "backend": "ollama",
-                    "url": "http://localhost:8080/v1",
-                },
-                "query": {
-                    "prompt": "Test prompt",
-                    "response_schema": schema,
-                },
-            }
-            config_file = tmp_path / f"config_schema_{schema}.json"
-            config_file.write_text(json.dumps(config))
-
-            result = runner.invoke(ai_app, ["run", "-c", str(config_file), str(sample_video_file)])
-            assert result.exit_code != 0
 
     def test_run_output_file_created(self, sample_config_file: Path, sample_video_file: Path, tmp_path: Path) -> None:
         output_file = tmp_path / "result.json"
@@ -399,8 +379,13 @@ class TestRunEvaluateCommand:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    is_correct=True,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test features",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=1.0,
@@ -455,8 +440,13 @@ class TestRunEvaluateCommand:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    is_correct=True,
-                    raw_result="domestic cat",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test features",
+                        species_name="domestic cat",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="cat",
                     comparison_method="llm",
                     processing_time_seconds=1.0,
@@ -496,8 +486,13 @@ class TestRunEvaluateCommand:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    is_correct=True,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test features",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=1.5,
@@ -539,8 +534,13 @@ class TestRunEvaluateCommand:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    is_correct=True,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test features",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=2.0,

--- a/tests/lib/ai/llm/test_llamacpp.py
+++ b/tests/lib/ai/llm/test_llamacpp.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from wildcamtools.lib.ai import SpeciesResult, StringResponse
+from wildcamtools.lib.ai import RichResult
 from wildcamtools.lib.ai.llm.abstract import DEFAULT_SYSTEM_MESSAGE
 from wildcamtools.lib.ai.llm.llamacpp import LlamaCppLlm
 
@@ -41,7 +41,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -49,7 +55,7 @@ class TestLlamaCppLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         mock_client.chat.completions.create.assert_called_once()
@@ -66,7 +72,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -74,47 +86,44 @@ class TestLlamaCppLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.completions.create.call_args
         messages = call_args.kwargs["messages"]
         system_content = messages[0]["content"]
 
-        expected_schema = SpeciesResult.model_json_schema()
         assert "species_name" in system_content
-        assert json.dumps(expected_schema) in system_content or expected_schema["properties"] is not None
+        assert "Expected JSON schema" in system_content
 
     @patch("wildcamtools.lib.ai.llm.llamacpp.openai_lib.OpenAI")
-    def test_message_with_schema_different_response_classes(
-        self, mock_client_class: MagicMock, sample_image: Path
-    ) -> None:
+    def test_message_with_schema_rich_result(self, mock_client_class: MagicMock, sample_image: Path) -> None:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
         llm = LlamaCppLlm(model="test-model", base_url="http://localhost:8080/v1")
+        llm.message_with_schema(
+            message="Test message",
+            images=[sample_image],
+            response_class=RichResult,
+        )
 
-        for response_class in [SpeciesResult, StringResponse]:
-            mock_client.chat.completions.create.reset_mock()
-            mock_response.choices[0].message.content = (
-                '{"species_name": "test"}' if response_class == SpeciesResult else '{"message": "test"}'
-            )
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        system_content = messages[0]["content"]
 
-            llm.message_with_schema(
-                message="Test message",
-                images=[sample_image],
-                response_class=response_class,
-            )
-
-            call_args = mock_client.chat.completions.create.call_args
-            messages = call_args.kwargs["messages"]
-            system_content = messages[0]["content"]
-
-            schema = response_class.model_json_schema()
-            assert any(prop in system_content for prop in schema.get("properties", {}))
+        schema = RichResult.model_json_schema()
+        assert any(prop in system_content for prop in schema.get("properties", {}))
 
     @patch("wildcamtools.lib.ai.llm.llamacpp.openai_lib.OpenAI")
     def test_custom_system_message_receives_schema(self, mock_client_class: MagicMock, sample_image: Path) -> None:
@@ -122,7 +131,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -134,7 +149,7 @@ class TestLlamaCppLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.completions.create.call_args
@@ -142,7 +157,7 @@ class TestLlamaCppLlmSystemMessage:
         system_content = messages[0]["content"]
 
         assert system_content.startswith("Custom:")
-        schema = SpeciesResult.model_json_schema()
+        schema = RichResult.model_json_schema()
         assert any(prop in system_content for prop in schema.get("properties", {}))
 
     @pytest.mark.parametrize("image_count", [0, 1, 3, 5])
@@ -153,7 +168,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -167,7 +188,7 @@ class TestLlamaCppLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=images,
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.completions.create.call_args
@@ -186,7 +207,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -196,7 +223,7 @@ class TestLlamaCppLlmSystemMessage:
             llm.message_with_schema(
                 message="Test message",
                 images=[sample_image],
-                response_class=SpeciesResult,
+                response_class=RichResult,
             )
 
         assert "System message:" in caplog.text
@@ -207,7 +234,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -215,7 +248,7 @@ class TestLlamaCppLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.completions.create.call_args
@@ -227,7 +260,13 @@ class TestLlamaCppLlmSystemMessage:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"species_name": "test"}'
+        mock_response.choices[0].message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client.chat.completions.create.return_value = mock_response
         mock_client_class.return_value = mock_client
 
@@ -235,7 +274,7 @@ class TestLlamaCppLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.completions.create.call_args

--- a/tests/lib/ai/llm/test_ollama.py
+++ b/tests/lib/ai/llm/test_ollama.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from wildcamtools.lib.ai import SpeciesResult, StringResponse
+from wildcamtools.lib.ai import RichResult
 from wildcamtools.lib.ai.llm.abstract import DEFAULT_SYSTEM_MESSAGE
 from wildcamtools.lib.ai.llm.ollama import OllamaLlm
 
@@ -36,14 +36,20 @@ class TestOllamaLlmSystemMessage:
     ) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"species_name": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         llm = OllamaLlm(model="test-model")
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         mock_client.chat.assert_called_once()
@@ -59,67 +65,75 @@ class TestOllamaLlmSystemMessage:
     def test_message_with_schema_includes_json_schema(self, mock_client_class: MagicMock, sample_image: Path) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"species_name": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         llm = OllamaLlm(model="test-model")
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.call_args
         messages = call_args.kwargs["messages"]
         system_content = messages[0]["content"]
 
-        expected_schema = SpeciesResult.model_json_schema()
         assert "species_name" in system_content
-        assert json.dumps(expected_schema) in system_content or expected_schema["properties"] is not None
+        assert "Expected JSON schema" in system_content
 
     @patch("wildcamtools.lib.ai.llm.ollama.ollama_lib.Client")
-    def test_message_with_schema_different_response_classes(
-        self, mock_client_class: MagicMock, sample_image: Path
-    ) -> None:
+    def test_message_with_schema_rich_result(self, mock_client_class: MagicMock, sample_image: Path) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"message": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         llm = OllamaLlm(model="test-model")
+        llm.message_with_schema(
+            message="Test message",
+            images=[sample_image],
+            response_class=RichResult,
+        )
 
-        for response_class in [SpeciesResult, StringResponse]:
-            mock_client.chat.reset_mock()
-            mock_client.chat.return_value.message.content = (
-                '{"species_name": "test"}' if response_class == SpeciesResult else '{"message": "test"}'
-            )
+        call_args = mock_client.chat.call_args
+        messages = call_args.kwargs["messages"]
+        system_content = messages[0]["content"]
 
-            llm.message_with_schema(
-                message="Test message",
-                images=[sample_image],
-                response_class=response_class,
-            )
-
-            call_args = mock_client.chat.call_args
-            messages = call_args.kwargs["messages"]
-            system_content = messages[0]["content"]
-
-            schema = response_class.model_json_schema()
-            assert any(prop in system_content for prop in schema.get("properties", {}))
+        schema = RichResult.model_json_schema()
+        assert any(prop in system_content for prop in schema.get("properties", {}))
 
     @patch("wildcamtools.lib.ai.llm.ollama.ollama_lib.Client")
     def test_custom_system_message_receives_schema(self, mock_client_class: MagicMock, sample_image: Path) -> None:
         custom_message = "Custom: {schema}"
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"species_name": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         llm = OllamaLlm(model="test-model", system_message=custom_message)
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.call_args
@@ -127,7 +141,7 @@ class TestOllamaLlmSystemMessage:
         system_content = messages[0]["content"]
 
         assert system_content.startswith("Custom:")
-        schema = SpeciesResult.model_json_schema()
+        schema = RichResult.model_json_schema()
         assert any(prop in system_content for prop in schema.get("properties", {}))
 
     @pytest.mark.parametrize("image_count", [0, 1, 3, 5])
@@ -137,7 +151,13 @@ class TestOllamaLlmSystemMessage:
     ) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"species_name": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         images = []
@@ -150,7 +170,7 @@ class TestOllamaLlmSystemMessage:
         llm.message_with_schema(
             message="Test message",
             images=images,
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.call_args
@@ -168,7 +188,13 @@ class TestOllamaLlmSystemMessage:
 
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"species_name": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         llm = OllamaLlm(model="test-model")
@@ -177,7 +203,7 @@ class TestOllamaLlmSystemMessage:
             llm.message_with_schema(
                 message="Test message",
                 images=[sample_image],
-                response_class=SpeciesResult,
+                response_class=RichResult,
             )
 
         assert "System message:" in caplog.text
@@ -187,16 +213,22 @@ class TestOllamaLlmSystemMessage:
     def test_message_with_schema_preserves_other_params(self, mock_client_class: MagicMock, sample_image: Path) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
-        mock_client.chat.return_value.message.content = '{"species_name": "test"}'
+        mock_client.chat.return_value.message.content = json.dumps({
+            "is_animal_present": True,
+            "is_animal_unknown": False,
+            "defining_features": "test features",
+            "species_name": "test",
+            "confidence": "high",
+        })
         mock_client_class.return_value = mock_client
 
         llm = OllamaLlm(model="qwen3.5:cloud", host="http://custom-host:11434")
         llm.message_with_schema(
             message="Test message",
             images=[sample_image],
-            response_class=SpeciesResult,
+            response_class=RichResult,
         )
 
         call_args = mock_client.chat.call_args
         assert call_args.kwargs["model"] == "qwen3.5:cloud"
-        assert call_args.kwargs["format"] == SpeciesResult.model_json_schema()
+        assert call_args.kwargs["format"] == RichResult.model_json_schema()

--- a/tests/lib/ai/test_label_comparison.py
+++ b/tests/lib/ai/test_label_comparison.py
@@ -2,32 +2,140 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from wildcamtools.lib.ai import BoolResponse
+from wildcamtools.lib.ai import BoolResponse, RichResult
 from wildcamtools.lib.ai.label_comparison import (
     ExactLabelComparator,
     LLMLabelComparator,
 )
-from wildcamtools.lib.ai.types import ResultClassification
+from wildcamtools.lib.ai.types import ConfidenceLevel, ResultClassification
 
 
 class TestExactLabelComparator:
     def test_exact_match_case_insensitive(self) -> None:
         comparator = ExactLabelComparator()
-        assert comparator.compare("cat", "cat") == (True, ResultClassification.CORRECT)
-        assert comparator.compare("CAT", "cat") == (True, ResultClassification.CORRECT)
-        assert comparator.compare("Cat", "CAT") == (True, ResultClassification.CORRECT)
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cat",
+            )
+            == ResultClassification.CORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="CAT",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cat",
+            )
+            == ResultClassification.CORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="Cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "CAT",
+            )
+            == ResultClassification.CORRECT
+        )
 
     def test_exact_match_mismatch(self) -> None:
         comparator = ExactLabelComparator()
-        assert comparator.compare("cat", "dog") == (False, ResultClassification.INCORRECT)
-        assert comparator.compare("cat", "cats") == (False, ResultClassification.INCORRECT)
-        assert comparator.compare("domestic cat", "cat") == (False, ResultClassification.INCORRECT)
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "dog",
+            )
+            == ResultClassification.INCORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cats",
+            )
+            == ResultClassification.INCORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="domestic cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cat",
+            )
+            == ResultClassification.INCORRECT
+        )
 
     def test_unknown_result(self) -> None:
         comparator = ExactLabelComparator()
-        assert comparator.compare("unknown", "cat") == (False, ResultClassification.UNKNOWN)
-        assert comparator.compare("Uncertain", "dog") == (False, ResultClassification.UNKNOWN)
-        assert comparator.compare("unsure", "bird") == (False, ResultClassification.UNKNOWN)
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="unknown",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cat",
+            )
+            == ResultClassification.UNKNOWN
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="Uncertain",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "dog",
+            )
+            == ResultClassification.UNKNOWN
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="unsure",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "bird",
+            )
+            == ResultClassification.UNKNOWN
+        )
 
     def test_method_name(self) -> None:
         comparator = ExactLabelComparator()
@@ -49,9 +157,45 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        assert comparator.compare("domestic cat", "cat") == (True, ResultClassification.CORRECT)
-        assert comparator.compare("Moorhen", "bird") == (True, ResultClassification.CORRECT)
-        assert comparator.compare("Roe deer", "deer") == (True, ResultClassification.CORRECT)
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="domestic cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cat",
+            )
+            == ResultClassification.CORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="Moorhen",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "bird",
+            )
+            == ResultClassification.CORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="Roe deer",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "deer",
+            )
+            == ResultClassification.CORRECT
+        )
 
     def test_semantic_match_general_to_specific(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
@@ -59,14 +203,74 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=False)
         mock_llm.message_with_schema.return_value = mock_response
 
-        assert comparator.compare("cat", "domestic cat") == (False, ResultClassification.INCORRECT)
-        assert comparator.compare("bird", "Moorhen") == (False, ResultClassification.INCORRECT)
-        assert comparator.compare("deer", "Roe deer") == (False, ResultClassification.INCORRECT)
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "domestic cat",
+            )
+            == ResultClassification.INCORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="bird",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "Moorhen",
+            )
+            == ResultClassification.INCORRECT
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="unknown",
+                    species_name="deer",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "Roe deer",
+            )
+            == ResultClassification.INCORRECT
+        )
 
     def test_unknown_result(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
-        assert comparator.compare("unknown", "cat") == (False, ResultClassification.UNKNOWN)
-        assert comparator.compare("uncertain", "dog") == (False, ResultClassification.UNKNOWN)
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="unknown",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "cat",
+            )
+            == ResultClassification.UNKNOWN
+        )
+        assert (
+            comparator.compare(
+                RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="uncertain",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
+                "dog",
+            )
+            == ResultClassification.UNKNOWN
+        )
 
     def test_caching(self, mock_llm: MagicMock) -> None:
         comparator = LLMLabelComparator(llm=mock_llm)
@@ -74,8 +278,26 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         assert mock_llm.message_with_schema.call_count == 1
 
@@ -85,9 +307,27 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
         comparator.clear_cache()
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         assert mock_llm.message_with_schema.call_count == 2
 
@@ -97,8 +337,26 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         assert mock_llm.message_with_schema.call_count == 2
         assert comparator._cache is None
@@ -109,7 +367,16 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         assert mock_llm.message_with_schema.call_count == 1
 
@@ -119,7 +386,16 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=False)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         assert mock_llm.message_with_schema.call_count == 1
 
@@ -130,7 +406,16 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         mock_llm.message_with_schema.assert_called_once()
         call_args = mock_llm.message_with_schema.call_args
@@ -142,9 +427,19 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         call_args = mock_llm.message_with_schema.call_args
+        assert call_args is not None
         assert "You are comparing an AI classification result" in call_args.kwargs["message"]
 
     def test_method_name(self, mock_llm: MagicMock) -> None:
@@ -157,7 +452,25 @@ class TestLLMLabelComparator:
         mock_response = BoolResponse(answer=True)
         mock_llm.message_with_schema.return_value = mock_response
 
-        comparator.compare("Domestic Cat", "CAT")
-        comparator.compare("domestic cat", "cat")
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="Domestic Cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "CAT",
+        )
+        comparator.compare(
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="unknown",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            "cat",
+        )
 
         assert mock_llm.message_with_schema.call_count == 1

--- a/tests/lib/ai/test_pipeline.py
+++ b/tests/lib/ai/test_pipeline.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Generator, Sequence
 from pathlib import Path
-from typing import TypeVar
 
 import cv2
 import numpy as np
@@ -23,9 +22,7 @@ from wildcamtools.lib.ai.pipeline import (
     SSIMFrameSelector,
     VerifiedImageBatchQuery,
 )
-from wildcamtools.lib.ai.types import ConfidenceLevel, FrameResult, Result, ResultList, VerificationResult
-
-T = TypeVar("T", bound=BaseModel)
+from wildcamtools.lib.ai.types import ConfidenceLevel, FrameResult, Result, ResultList, RichResult, VerificationResult
 
 
 @pytest.fixture(name="sample_frames")
@@ -110,29 +107,40 @@ class MockAbstractLlm(AbstractLlm):
         url: str = "http://test",
         response_to_return: str = "test_species",
         result_list_to_return: ResultList | None = None,
+        return_rich_result: bool = False,
     ) -> None:
         self.model = model
         self.backend = backend
         self.url = url
         self.response_to_return = response_to_return
         self.result_list_to_return = result_list_to_return
+        self.return_rich_result = return_rich_result
         self.call_count = 0
         self.last_images: list[Path] = []
         self.last_prompt: str = ""
 
-    def message_with_schema[T](
+    def message_with_schema(
         self,
         message: str,
         images: Sequence[Path] = (),
-        response_class: type[T] = MockSpeciesResult,  # type: ignore[assignment]
-    ) -> T:
+        response_class: type = RichResult,
+    ):
         self.call_count += 1
         self.last_images = list(images)
         self.last_prompt = message
         if response_class is ResultList and self.result_list_to_return is not None:
-            return self.result_list_to_return  # type: ignore[return-value]
-        result = MockSpeciesResult(species_name=self.response_to_return)
-        return result  # type: ignore[return-value]
+            return self.result_list_to_return
+        if response_class is RichResult:
+            result = RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test features",
+                species_name=self.response_to_return,
+                confidence=ConfidenceLevel.HIGH,
+            )
+        else:
+            result = MockSpeciesResult(species_name=self.response_to_return)
+        return result
 
 
 class MockVerifiedLlm(AbstractLlm):
@@ -165,12 +173,12 @@ class MockVerifiedLlm(AbstractLlm):
         self.last_prompt: str = ""
         self.verification_prompt: str = ""
 
-    def message_with_schema[T](
+    def message_with_schema(
         self,
         message: str,
         images: Sequence[Path] = (),
-        response_class: type[T] = MockSpeciesResult,  # type: ignore[assignment]
-    ) -> T:
+        response_class: type = RichResult,
+    ):
         self.call_count += 1
         self.last_images = list(images)
 
@@ -181,11 +189,17 @@ class MockVerifiedLlm(AbstractLlm):
                 confidence=self.verification_confidence,
                 verified=self.verification_verified,
             )
-            return result  # type: ignore[return-value]
+            return result
         else:
             self.last_prompt = message
-            result = MockSpeciesResult(species_name=self.initial_species)
-            return result  # type: ignore[return-value]
+            result = RichResult(
+                is_animal_present=self.initial_species not in ("unknown", "no animal"),
+                is_animal_unknown=self.initial_species == "unknown",
+                defining_features="test features",
+                species_name=self.initial_species,
+                confidence=ConfidenceLevel.HIGH,
+            )
+            return result
 
 
 class TestFpsRescalingFrameSelector:
@@ -1073,25 +1087,22 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt=prompt,
-            response_class=MockSpeciesResult,
         )
         assert query.llm is mock_llm
         assert query.prompt == prompt
-        assert query.response_class is MockSpeciesResult
 
-    def test_query_images_returns_model_instance(
+    def test_query_images_returns_rich_result(
         self,
         sample_image_paths: list[Path],
     ) -> None:
-        """Test query_images returns a model instance."""
+        """Test query_images returns a RichResult instance."""
         mock_llm = MockAbstractLlm()
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         result = query.query_images(sample_image_paths)
-        assert isinstance(result, MockSpeciesResult)
+        assert isinstance(result, RichResult)
         assert result.species_name == "test_species"
 
     def test_query_images_calls_analyser(
@@ -1103,7 +1114,6 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         query.query_images(sample_image_paths)
         assert mock_llm.call_count == 1
@@ -1117,7 +1127,6 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         query.query_images(list(reversed(sample_image_paths)))
         assert mock_llm.last_images == sorted(sample_image_paths)
@@ -1132,7 +1141,6 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt=custom_prompt,
-            response_class=MockSpeciesResult,
         )
         query.query_images(sample_image_paths)
         assert mock_llm.last_prompt == custom_prompt
@@ -1146,7 +1154,6 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         result = query.query_images(sample_image_paths)
         assert result.species_name == "custom_species"
@@ -1157,7 +1164,6 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         with pytest.raises(ValueError, match="Empty image batch"):
             query.query_images([])
@@ -1171,12 +1177,11 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         batches = [sample_image_paths, sample_image_paths]
         results = list(query.query_image_batches(batches))
         assert len(results) == 2
-        assert all(isinstance(r, MockSpeciesResult) for r in results)
+        assert all(isinstance(r, RichResult) for r in results)
 
     def test_query_image_batches_multiple_batches(
         self,
@@ -1187,7 +1192,6 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         batches = [sample_image_paths, sample_image_paths, sample_image_paths]
         list(query.query_image_batches(batches))
@@ -1204,27 +1208,11 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         batches = [sample_image_paths] * batch_count
         results = list(query.query_image_batches(batches))
         assert len(results) == batch_count
         assert mock_llm.call_count == batch_count
-
-    def test_query_images_return_type_matches_response_class(
-        self,
-        sample_image_paths: list[Path],
-    ) -> None:
-        """Test returned instance matches response_class."""
-        mock_llm = MockAbstractLlm()
-        query = LlmImageBatchQuery(
-            llm=mock_llm,
-            prompt="Test prompt",
-            response_class=MockSpeciesResult,
-        )
-        result = query.query_images(sample_image_paths)
-        assert isinstance(result, MockSpeciesResult)
-        assert type(result) is MockSpeciesResult
 
     def test_query_images_single_image(
         self,
@@ -1235,10 +1223,9 @@ class TestLlmImageBatchQuery:
         query = LlmImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         result = query.query_images([sample_image_paths[0]])
-        assert isinstance(result, MockSpeciesResult)
+        assert isinstance(result, RichResult)
         assert mock_llm.call_count == 1
 
 
@@ -1247,98 +1234,147 @@ class TestMajorityResultReconciler:
 
     def test_reconciler_with_single_result(self) -> None:
         """Test reconciler returns single result unchanged."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
-        result = reconciler.reconcile_results([MockSpeciesResult(species_name="test")])
-        assert result.species_name == "test"
+        reconciler = MajorityResultReconciler()
+        result = reconciler.reconcile_results([
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test features",
+                species_name="test_species",
+                confidence=ConfidenceLevel.HIGH,
+            )
+        ])
+        assert result.species_name == "test_species"
 
     def test_reconciler_with_identical_results(self) -> None:
-        """Test reconciler returns result when all are identical."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
-        results = [MockSpeciesResult(species_name="same") for _ in range(5)]
+        """Test reconciler returns identical result."""
+        reconciler = MajorityResultReconciler()
+        results = [
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="same",
+                confidence=ConfidenceLevel.HIGH,
+            )
+            for _ in range(5)
+        ]
         result = reconciler.reconcile_results(results)
         assert result.species_name == "same"
 
     def test_reconciler_with_clear_majority(self) -> None:
-        """Test reconciler returns majority result."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
+        """Test reconciler selects majority result."""
+        reconciler = MajorityResultReconciler()
         results = [
-            MockSpeciesResult(species_name="A"),
-            MockSpeciesResult(species_name="A"),
-            MockSpeciesResult(species_name="A"),
-            MockSpeciesResult(species_name="B"),
-            MockSpeciesResult(species_name="B"),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="A",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="A",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="A",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="B",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="B",
+                confidence=ConfidenceLevel.HIGH,
+            ),
         ]
         result = reconciler.reconcile_results(results)
         assert result.species_name == "A"
 
-    def test_reconciler_with_tie_takes_first(self) -> None:
-        """Test reconciler returns first-seen result in case of tie."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
+    def test_reconciler_with_tie_breaks_with_first_seen(self) -> None:
+        """Test reconciler breaks ties by selecting first-seen."""
+        reconciler = MajorityResultReconciler()
         results = [
-            MockSpeciesResult(species_name="A"),
-            MockSpeciesResult(species_name="B"),
-            MockSpeciesResult(species_name="B"),
-            MockSpeciesResult(species_name="A"),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="A",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="B",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="A",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="B",
+                confidence=ConfidenceLevel.HIGH,
+            ),
         ]
         result = reconciler.reconcile_results(results)
         assert result.species_name == "A"
 
-    def test_reconciler_with_empty_results_raises_error(self) -> None:
-        """Test reconciler raises error with empty results."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
+    def test_reconciler_with_empty_results_raises(self) -> None:
+        """Test reconciler raises ValueError on empty input."""
+        reconciler = MajorityResultReconciler()
         with pytest.raises(ValueError, match="No results to reconcile"):
             reconciler.reconcile_results([])
 
-    def test_reconciler_preserves_object_identity(self) -> None:
-        """Test reconciler returns one of the input objects, not a copy."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
-        result_obj = MockSpeciesResult(species_name="test")
-        results = [result_obj, result_obj, result_obj]
-        result = reconciler.reconcile_results(results)
-        assert result is result_obj
-
-    @pytest.mark.parametrize("count", [1, 2, 3, 5, 10])
-    def test_reconciler_with_varying_result_counts(
-        self,
-        count: int,
-    ) -> None:
-        """Test reconciler with varying numbers of results."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
-        results = [MockSpeciesResult(species_name="majority")] * count
-        result = reconciler.reconcile_results(results)
-        assert result.species_name == "majority"
-
-    def test_reconciler_with_complex_tie_scenario(self) -> None:
-        """Test reconciler with multiple results tied for majority."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
+    def test_reconciler_with_all_different_results(self) -> None:
+        """Test reconciler returns first result when all are different."""
+        reconciler = MajorityResultReconciler()
         results = [
-            MockSpeciesResult(species_name="A"),
-            MockSpeciesResult(species_name="B"),
-            MockSpeciesResult(species_name="C"),
-            MockSpeciesResult(species_name="A"),
-            MockSpeciesResult(species_name="B"),
-            MockSpeciesResult(species_name="C"),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="A",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="B",
+                confidence=ConfidenceLevel.HIGH,
+            ),
+            RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="C",
+                confidence=ConfidenceLevel.HIGH,
+            ),
         ]
         result = reconciler.reconcile_results(results)
         assert result.species_name == "A"
-
-    def test_reconciler_with_generator_input(self) -> None:
-        """Test reconciler accepts generator/iterator input."""
-        reconciler: MajorityResultReconciler[MockSpeciesResult] = MajorityResultReconciler()
-
-        def result_generator() -> Generator[MockSpeciesResult]:
-            for _ in range(3):
-                yield MockSpeciesResult(species_name="A")
-
-        result = reconciler.reconcile_results(result_generator())
-        assert result.species_name == "A"
-
-    def test_reconciler_with_string_results(self) -> None:
-        """Test reconciler works with non-BaseModel types."""
-        reconciler: MajorityResultReconciler[str] = MajorityResultReconciler()
-        results = ["A", "A", "B", "A", "B"]
-        result = reconciler.reconcile_results(results)
-        assert result == "A"
 
 
 class TestVerifiedImageBatchQuery:
@@ -1351,11 +1387,9 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt=prompt,
-            response_class=MockSpeciesResult,
         )
         assert query.llm is mock_llm
         assert query.prompt == prompt
-        assert query.response_class is MockSpeciesResult
         assert query.min_confidence == ConfidenceLevel.MEDIUM
 
     def test_verified_query_with_custom_min_confidence(self) -> None:
@@ -1364,7 +1398,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
             min_confidence=ConfidenceLevel.HIGH,
         )
         assert query.min_confidence == ConfidenceLevel.HIGH
@@ -1376,7 +1409,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
             verification_prompt=custom_prompt,
         )
         assert query.verification_prompt == custom_prompt
@@ -1390,27 +1422,26 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         query.query_images(sample_image_paths)
         assert mock_llm.call_count == 2
 
-    def test_verified_query_returns_verification_result(
+    def test_verified_query_returns_rich_result(
         self,
         sample_image_paths: list[Path],
     ) -> None:
-        """Test query_images returns VerificationResult."""
+        """Test query_images returns RichResult."""
         mock_llm = MockVerifiedLlm()
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         result = query.query_images(sample_image_paths)
-        assert isinstance(result, VerificationResult)
+        assert isinstance(result, RichResult)
         assert result.species_name == "fox"
         assert result.confidence == ConfidenceLevel.HIGH
-        assert result.verified is True
+        assert result.is_animal_present is True
+        assert result.is_animal_unknown is False
 
     def test_verified_query_passes_initial_species_to_verification(
         self,
@@ -1421,7 +1452,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         query.query_images(sample_image_paths)
         assert "badger" in mock_llm.verification_prompt
@@ -1438,12 +1468,10 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
             min_confidence=ConfidenceLevel.MEDIUM,
         )
         result = query.query_images(sample_image_paths)
-        assert result.species_name == "unknown"
-        assert result.verified is False
+        assert result.is_animal_unknown is True
         assert result.confidence == ConfidenceLevel.LOW
 
     def test_verified_query_medium_confidence_passes_with_medium_threshold(
@@ -1457,12 +1485,11 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
             min_confidence=ConfidenceLevel.MEDIUM,
         )
         result = query.query_images(sample_image_paths)
         assert result.species_name == "fox"
-        assert result.verified is True
+        assert result.is_animal_present is True
 
     def test_verified_query_medium_confidence_fails_with_high_threshold(
         self,
@@ -1475,12 +1502,10 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
             min_confidence=ConfidenceLevel.HIGH,
         )
         result = query.query_images(sample_image_paths)
-        assert result.species_name == "unknown"
-        assert result.verified is False
+        assert result.is_animal_unknown is True
 
     def test_verified_query_high_confidence_passes_all_thresholds(
         self,
@@ -1494,12 +1519,11 @@ class TestVerifiedImageBatchQuery:
             query = VerifiedImageBatchQuery(
                 llm=mock_llm,
                 prompt="Test prompt",
-                response_class=MockSpeciesResult,
                 min_confidence=threshold,
             )
             result = query.query_images(sample_image_paths)
             assert result.species_name == "fox"
-            assert result.verified is True
+            assert result.is_animal_present is True
 
     def test_verified_query_empty_batch_raises_error(self) -> None:
         """Test empty batch raises ValueError."""
@@ -1507,7 +1531,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         with pytest.raises(ValueError, match="Empty image batch"):
             query.query_images([])
@@ -1521,7 +1544,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         query.query_images(list(reversed(sample_image_paths)))
         assert mock_llm.last_images == sorted(sample_image_paths)
@@ -1539,11 +1561,11 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         result = query.query_images(sample_image_paths)
         assert result.species_name == "badger"
-        assert result.verified is True
+        assert result.is_animal_present is True
+        assert result.is_animal_unknown is False
 
     def test_verified_query_verified_false_becomes_unknown(
         self,
@@ -1557,27 +1579,24 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         result = query.query_images(sample_image_paths)
-        assert result.species_name == "unknown"
-        assert result.verified is False
+        assert result.is_animal_unknown is True
 
-    def test_query_image_batches_yields_verification_results(
+    def test_query_image_batches_yields_rich_results(
         self,
         sample_image_paths: list[Path],
     ) -> None:
-        """Test query_image_batches yields VerificationResult for each batch."""
+        """Test query_image_batches yields RichResult for each batch."""
         mock_llm = MockVerifiedLlm()
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         batches = [sample_image_paths, sample_image_paths]
         results = list(query.query_image_batches(batches))
         assert len(results) == 2
-        assert all(isinstance(r, VerificationResult) for r in results)
+        assert all(isinstance(r, RichResult) for r in results)
 
     def test_query_image_batches_multiple_batches(
         self,
@@ -1588,7 +1607,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         batches = [sample_image_paths, sample_image_paths, sample_image_paths]
         list(query.query_image_batches(batches))
@@ -1605,7 +1623,6 @@ class TestVerifiedImageBatchQuery:
         query = VerifiedImageBatchQuery(
             llm=mock_llm,
             prompt="Test prompt",
-            response_class=MockSpeciesResult,
         )
         batches = [sample_image_paths] * batch_count
         results = list(query.query_image_batches(batches))
@@ -1622,9 +1639,8 @@ class TestVerifiedImageBatchQuery:
             query = VerifiedImageBatchQuery(
                 llm=mock_llm,
                 prompt="Test prompt",
-                response_class=MockSpeciesResult,
                 min_confidence=ConfidenceLevel.LOW,
             )
             result = query.query_images(sample_image_paths)
             assert result.species_name == "fox"
-            assert result.verified is True
+            assert result.is_animal_present is True

--- a/tests/lib/ai/test_pipeline_config.py
+++ b/tests/lib/ai/test_pipeline_config.py
@@ -23,7 +23,6 @@ from wildcamtools.lib.ai.pipeline_config import (
     LlmConfig,
     ReconcilerConfig,
     ReconcilerType,
-    ResponseSchemaType,
 )
 
 
@@ -440,7 +439,6 @@ class TestImageBatchQueryConfig:
         config = ImageBatchQueryConfig(prompt="Test prompt")
         assert config.query_type == ImageBatchQueryType.LLM
         assert config.prompt == "Test prompt"
-        assert config.response_schema == ResponseSchemaType.SPECIES_RESULT
         assert config.verification_prompt is None
         assert config.min_confidence == "medium"
 
@@ -448,13 +446,11 @@ class TestImageBatchQueryConfig:
         config = ImageBatchQueryConfig(
             query_type=ImageBatchQueryType.VERIFIED,
             prompt="Custom prompt",
-            response_schema=ResponseSchemaType.STRING_RESPONSE,
             verification_prompt="Verify: {initial_species}",
             min_confidence="high",
         )
         assert config.query_type == ImageBatchQueryType.VERIFIED
         assert config.prompt == "Custom prompt"
-        assert config.response_schema == ResponseSchemaType.STRING_RESPONSE
         assert config.verification_prompt == "Verify: {initial_species}"
         assert config.min_confidence == "high"
 
@@ -462,40 +458,6 @@ class TestImageBatchQueryConfig:
         with pytest.raises(ValidationError) as exc_info:
             ImageBatchQueryConfig(prompt="")
         assert "min_length=1" in str(exc_info.value) or "at least 1" in str(exc_info.value).lower()
-
-    @pytest.mark.parametrize(
-        "schema_value,expected_class",
-        [
-            ("SpeciesResult", "SpeciesResult"),
-            ("Result", "Result"),
-            ("StringResponse", "StringResponse"),
-        ],
-    )
-    def test_response_schema_values(self, schema_value: str, expected_class: str) -> None:
-        config = ImageBatchQueryConfig.model_validate({"prompt": "test", "response_schema": schema_value})
-        assert config.response_schema.value == expected_class
-
-    def test_invalid_response_schema(self) -> None:
-        with pytest.raises(ValidationError):
-            ImageBatchQueryConfig.model_validate({"prompt": "test", "response_schema": "InvalidSchema"})
-
-    def test_get_response_class_species(self) -> None:
-        from wildcamtools.lib.ai import SpeciesResult
-
-        config = ImageBatchQueryConfig(prompt="test", response_schema=ResponseSchemaType.SPECIES_RESULT)
-        assert config.get_response_class() == SpeciesResult
-
-    def test_get_response_class_result(self) -> None:
-        from wildcamtools.lib.ai import Result
-
-        config = ImageBatchQueryConfig(prompt="test", response_schema=ResponseSchemaType.RESULT)
-        assert config.get_response_class() == Result
-
-    def test_get_response_class_string(self) -> None:
-        from wildcamtools.lib.ai import StringResponse
-
-        config = ImageBatchQueryConfig(prompt="test", response_schema=ResponseSchemaType.STRING_RESPONSE)
-        assert config.get_response_class() == StringResponse
 
     def test_strict_type_validation(self) -> None:
         with pytest.raises(ValidationError):
@@ -587,13 +549,12 @@ class TestAiPipelineConfig:
             frame_selector=FrameSelectorConfig(fps=0.5),
             frame_extractor=FrameExtractorConfig(resolution=(1280, 720)),
             llm=LlmConfig(model="llama-3", backend=Backend.LLAMACPP, url="http://localhost:8080/v1"),
-            query=ImageBatchQueryConfig(prompt="Custom prompt", response_schema=ResponseSchemaType.STRING_RESPONSE),
+            query=ImageBatchQueryConfig(prompt="Custom prompt"),
             reconciler=ReconcilerConfig(reconciler_type=ReconcilerType.MAJORITY),
         )
         assert config.frame_selector.fps == 0.5
         assert config.frame_extractor.resolution == (1280, 720)
         assert config.llm.backend == Backend.LLAMACPP
-        assert config.query.response_schema == ResponseSchemaType.STRING_RESPONSE
 
     def test_from_json(self, tmp_path: Path) -> None:
         json_content = """
@@ -663,7 +624,7 @@ class TestAiPipelineConfig:
             frame_selector=FrameSelectorConfig(fps=5.0),
             frame_extractor=FrameExtractorConfig(resolution=(1024, 768)),
             llm=LlmConfig(model="custom-model", url="http://example.com"),
-            query=ImageBatchQueryConfig(prompt="custom prompt", response_schema=ResponseSchemaType.RESULT),
+            query=ImageBatchQueryConfig(prompt="custom prompt"),
             reconciler=ReconcilerConfig(),
         )
 

--- a/tests/lib/ai/test_pipeline_evaluation.py
+++ b/tests/lib/ai/test_pipeline_evaluation.py
@@ -8,8 +8,7 @@ from wildcamtools.lib import Frame
 from wildcamtools.lib.ai import (
     PipelineEvaluationResult,
     PipelineEvaluationSummary,
-    SpeciesResult,
-    StringResponse,
+    RichResult,
 )
 from wildcamtools.lib.ai.label_comparison_config import LabelComparisonConfig
 from wildcamtools.lib.ai.pipeline import FrameSelector
@@ -20,17 +19,23 @@ from wildcamtools.lib.ai.pipeline_evaluation import (
     _WorkerResult,
     evaluate_ai_pipeline,
 )
-from wildcamtools.lib.ai.types import ResultClassification
+from wildcamtools.lib.ai.types import ConfidenceLevel, ResultClassification
 
 
 class TestWorkerResult:
     def test_worker_result_creation(self) -> None:
         result = _WorkerResult(
             filename="test.mp4",
-            raw_result="otter",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
         )
         assert result.filename == "test.mp4"
-        assert result.raw_result == "otter"
+        assert result.result.species_name == "otter"
         assert result.error is None
         assert result.processing_time_seconds == 0.0
         assert result.frame_ids == []
@@ -38,7 +43,13 @@ class TestWorkerResult:
     def test_worker_result_with_error(self) -> None:
         result = _WorkerResult(
             filename="test.mp4",
-            raw_result="",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             error="Connection timeout",
         )
         assert result.error == "Connection timeout"
@@ -48,7 +59,13 @@ class TestWorkerResult:
     def test_worker_result_with_processing_time(self) -> None:
         result = _WorkerResult(
             filename="test.mp4",
-            raw_result="otter",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             processing_time_seconds=1.5,
         )
         assert result.processing_time_seconds == 1.5
@@ -56,7 +73,13 @@ class TestWorkerResult:
     def test_worker_result_with_frame_ids(self) -> None:
         result = _WorkerResult(
             filename="test.mp4",
-            raw_result="otter",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             frame_ids=[1, 5, 10, 15],
         )
         assert result.frame_ids == [1, 5, 10, 15]
@@ -67,14 +90,18 @@ class TestPipelineEvaluationResult:
         result = PipelineEvaluationResult(
             filename="test.mp4",
             classification=ResultClassification.CORRECT,
-            raw_result="otter",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             label="otter",
-            is_correct=True,
         )
         assert result.filename == "test.mp4"
         assert result.classification == ResultClassification.CORRECT
-        assert result.correct is True
-        assert result.raw_result == "otter"
+        assert result.result.species_name == "otter"
         assert result.label == "otter"
         assert result.error is None
         assert result.comparison_method == "exact"
@@ -85,14 +112,18 @@ class TestPipelineEvaluationResult:
         result = PipelineEvaluationResult(
             filename="test.mp4",
             classification=ResultClassification.INCORRECT,
-            raw_result="",
+            result=RichResult(
+                is_animal_present=False,
+                is_animal_unknown=False,
+                defining_features="",
+                species_name="",
+                confidence=ConfidenceLevel.LOW,
+            ),
             label="otter",
             error="Connection timeout",
-            is_correct=False,
         )
         assert result.error == "Connection timeout"
         assert result.classification == ResultClassification.INCORRECT
-        assert result.correct is False
         assert result.processing_time_seconds == 0.0
         assert result.frame_ids == []
 
@@ -100,20 +131,31 @@ class TestPipelineEvaluationResult:
         result = PipelineEvaluationResult(
             filename="test.mp4",
             classification=ResultClassification.UNKNOWN,
-            raw_result="unknown",
+            result=RichResult(
+                is_animal_present=False,
+                is_animal_unknown=True,
+                defining_features="unknown",
+                species_name="unknown",
+                confidence=ConfidenceLevel.LOW,
+            ),
             label="otter",
         )
         assert result.classification == ResultClassification.UNKNOWN
-        assert result.correct is False
+        # result.correct field removed - classification UNKNOWN implies not correct
 
     def test_result_with_comparison_method(self) -> None:
         result = PipelineEvaluationResult(
             filename="test.mp4",
             classification=ResultClassification.CORRECT,
-            raw_result="domestic cat",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="domestic cat",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             label="cat",
             comparison_method="llm",
-            is_correct=True,
         )
         assert result.comparison_method == "llm"
         assert result.frame_ids == []
@@ -122,10 +164,15 @@ class TestPipelineEvaluationResult:
         result = PipelineEvaluationResult(
             filename="test.mp4",
             classification=ResultClassification.CORRECT,
-            raw_result="otter",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             label="otter",
             processing_time_seconds=1.5,
-            is_correct=True,
         )
         assert result.processing_time_seconds == 1.5
         assert result.frame_ids == []
@@ -134,10 +181,15 @@ class TestPipelineEvaluationResult:
         result = PipelineEvaluationResult(
             filename="test.mp4",
             classification=ResultClassification.CORRECT,
-            raw_result="otter",
+            result=RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence=ConfidenceLevel.HIGH,
+            ),
             label="otter",
             frame_ids=[1, 5, 10, 15],
-            is_correct=True,
         )
         assert result.frame_ids == [1, 5, 10, 15]
 
@@ -198,16 +250,26 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="cat",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -229,23 +291,38 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="cat",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="cat",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test3.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="dog",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="dog",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="cat",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -263,23 +340,38 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.UNKNOWN,
-                raw_result="unknown",
+                result=RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="unknown",
+                    confidence=ConfidenceLevel.LOW,
+                ),
                 label="otter",
-                is_correct=False,
             ),
             PipelineEvaluationResult(
                 filename="test3.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="dog",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="dog",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -297,17 +389,27 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="",
+                result=RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=False,
+                    defining_features="",
+                    species_name="",
+                    confidence=ConfidenceLevel.LOW,
+                ),
                 label="cat",
                 error="LLM error",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -336,9 +438,14 @@ class TestPipelineEvaluationSummary:
                 PipelineEvaluationResult(
                     filename=f"test_correct_{i}.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
-                    is_correct=True,
                 )
             )
         for i in range(incorrect):
@@ -346,9 +453,14 @@ class TestPipelineEvaluationSummary:
                 PipelineEvaluationResult(
                     filename=f"test_incorrect_{i}.mp4",
                     classification=ResultClassification.INCORRECT,
-                    raw_result="cat",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="cat",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
-                    is_correct=False,
                 )
             )
         summary = PipelineEvaluationSummary(
@@ -366,16 +478,26 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="cat",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="cat",
-                is_correct=True,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -393,16 +515,26 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="cat",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="cat",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -420,23 +552,38 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.UNKNOWN,
-                raw_result="unknown",
+                result=RichResult(
+                    is_animal_present=False,
+                    is_animal_unknown=True,
+                    defining_features="unknown",
+                    species_name="unknown",
+                    confidence=ConfidenceLevel.LOW,
+                ),
                 label="cat",
-                is_correct=False,
             ),
             PipelineEvaluationResult(
                 filename="test3.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="dog",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="dog",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="dog",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -454,16 +601,26 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.INCORRECT,
-                raw_result="cat",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="cat",
-                is_correct=False,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -481,26 +638,41 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
                 processing_time_seconds=1.0,
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test2.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="cat",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="cat",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="cat",
                 processing_time_seconds=2.0,
-                is_correct=True,
             ),
             PipelineEvaluationResult(
                 filename="test3.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="dog",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="dog",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="dog",
                 processing_time_seconds=3.0,
-                is_correct=True,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -519,10 +691,15 @@ class TestPipelineEvaluationSummary:
             PipelineEvaluationResult(
                 filename="test1.mp4",
                 classification=ResultClassification.CORRECT,
-                raw_result="otter",
+                result=RichResult(
+                    is_animal_present=True,
+                    is_animal_unknown=False,
+                    defining_features="test",
+                    species_name="otter",
+                    confidence=ConfidenceLevel.HIGH,
+                ),
                 label="otter",
                 processing_time_seconds=1.5,
-                is_correct=True,
             ),
         ]
         summary = PipelineEvaluationSummary(
@@ -546,7 +723,13 @@ class TestEvaluateVideoWorker:
         self,
         data_directory: Path,
     ) -> None:
-        mock_result = SpeciesResult(species_name="otter")
+        mock_result = RichResult(
+            is_animal_present=True,
+            is_animal_unknown=False,
+            defining_features="test",
+            species_name="otter",
+            confidence="high",
+        )
         mock_config = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.run.return_value = mock_result
@@ -556,7 +739,7 @@ class TestEvaluateVideoWorker:
         result = _evaluate_video_worker(str(video_path), mock_config)
 
         assert result.filename == "test.mp4"
-        assert result.raw_result == "otter"
+        assert result.result.species_name == "otter"
         assert result.error is None
         assert result.processing_time_seconds > 0.0
 
@@ -564,7 +747,13 @@ class TestEvaluateVideoWorker:
         self,
         data_directory: Path,
     ) -> None:
-        mock_result = SpeciesResult(species_name="cat")
+        mock_result = RichResult(
+            is_animal_present=True,
+            is_animal_unknown=False,
+            defining_features="test",
+            species_name="cat",
+            confidence="high",
+        )
         mock_config = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.run.return_value = mock_result
@@ -573,13 +762,19 @@ class TestEvaluateVideoWorker:
         video_path = data_directory / "test.mp4"
         result = _evaluate_video_worker(str(video_path), mock_config)
 
-        assert result.raw_result == "cat"
+        assert result.result.species_name == "cat"
 
     def test_worker_unknown_result_with_mock(
         self,
         data_directory: Path,
     ) -> None:
-        mock_result = SpeciesResult(species_name="unknown")
+        mock_result = RichResult(
+            is_animal_present=False,
+            is_animal_unknown=True,
+            defining_features="unknown",
+            species_name="unknown",
+            confidence="low",
+        )
         mock_config = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.run.return_value = mock_result
@@ -588,7 +783,7 @@ class TestEvaluateVideoWorker:
         video_path = data_directory / "test.mp4"
         result = _evaluate_video_worker(str(video_path), mock_config)
 
-        assert result.raw_result == "unknown"
+        assert result.result.species_name == "unknown"
 
     def test_worker_error_handling_with_mock(
         self,
@@ -603,11 +798,17 @@ class TestEvaluateVideoWorker:
         with pytest.raises(RuntimeError, match="LLM connection failed"):
             _evaluate_video_worker(str(video_path), mock_config)
 
-    def test_worker_with_string_response_result(
+    def test_worker_with_rich_result(
         self,
         data_directory: Path,
     ) -> None:
-        mock_result = StringResponse(message="test response")
+        mock_result = RichResult(
+            is_animal_present=True,
+            is_animal_unknown=False,
+            defining_features="test",
+            species_name="test response",
+            confidence="high",
+        )
         mock_config = MagicMock()
         mock_pipeline = MagicMock()
         mock_pipeline.run.return_value = mock_result
@@ -616,13 +817,19 @@ class TestEvaluateVideoWorker:
         video_path = data_directory / "test.mp4"
         result = _evaluate_video_worker(str(video_path), mock_config)
 
-        assert result.raw_result == "test response"
+        assert result.result.species_name == "test response"
 
     def test_worker_captures_frame_ids(
         self,
         data_directory: Path,
     ) -> None:
-        mock_result = SpeciesResult(species_name="otter")
+        mock_result = RichResult(
+            is_animal_present=True,
+            is_animal_unknown=False,
+            defining_features="test",
+            species_name="otter",
+            confidence="high",
+        )
         mock_frame_selector = MagicMock(spec=FrameSelector)
         frames = [
             Frame(raw=[], frame_no=1),
@@ -635,7 +842,7 @@ class TestEvaluateVideoWorker:
         mock_pipeline = MagicMock()
         mock_pipeline.frame_selector = mock_frame_selector
 
-        def run_side_effect(video_path: Path) -> SpeciesResult:
+        def run_side_effect(video_path: Path) -> RichResult:
             list(mock_pipeline.frame_selector.select_frames(video_path))
             return mock_result
 
@@ -741,7 +948,13 @@ class TestEvaluateAiPipeline:
         ):
             mock_config = MagicMock()
             mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = SpeciesResult(species_name="otter")
+            mock_pipeline.run.return_value = RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence="high",
+            )
             mock_config.create_pipeline.return_value = mock_pipeline
             mock_validate.return_value = mock_config
 
@@ -756,7 +969,13 @@ class TestEvaluateAiPipeline:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=1.0,
@@ -765,7 +984,13 @@ class TestEvaluateAiPipeline:
                 PipelineEvaluationResult(
                     filename="short.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="cat",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="cat",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="cat",
                     comparison_method="exact",
                     processing_time_seconds=3.0,
@@ -798,7 +1023,13 @@ class TestEvaluateAiPipeline:
         ):
             mock_config = MagicMock()
             mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = SpeciesResult(species_name="otter")
+            mock_pipeline.run.return_value = RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence="high",
+            )
             mock_config.create_pipeline.return_value = mock_pipeline
             mock_validate.return_value = mock_config
 
@@ -813,7 +1044,13 @@ class TestEvaluateAiPipeline:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=1.0,
@@ -822,7 +1059,13 @@ class TestEvaluateAiPipeline:
                 PipelineEvaluationResult(
                     filename="short.mp4",
                     classification=ResultClassification.INCORRECT,
-                    raw_result="",
+                    result=RichResult(
+                        is_animal_present=False,
+                        is_animal_unknown=False,
+                        defining_features="",
+                        species_name="",
+                        confidence=ConfidenceLevel.LOW,
+                    ),
                     label="cat",
                     error="LLM connection failed",
                     comparison_method="exact",
@@ -888,7 +1131,13 @@ class TestIntegration:
         ):
             mock_config = MagicMock()
             mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = SpeciesResult(species_name="otter")
+            mock_pipeline.run.return_value = RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence="high",
+            )
             mock_config.create_pipeline.return_value = mock_pipeline
             mock_validate.return_value = mock_config
 
@@ -903,7 +1152,13 @@ class TestIntegration:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=1.0,
@@ -912,7 +1167,13 @@ class TestIntegration:
                 PipelineEvaluationResult(
                     filename="short.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="cat",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="cat",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="cat",
                     comparison_method="exact",
                     processing_time_seconds=2.0,
@@ -978,7 +1239,13 @@ class TestIntegration:
         ):
             mock_config = MagicMock()
             mock_pipeline = MagicMock()
-            mock_pipeline.run.return_value = SpeciesResult(species_name="otter")
+            mock_pipeline.run.return_value = RichResult(
+                is_animal_present=True,
+                is_animal_unknown=False,
+                defining_features="test",
+                species_name="otter",
+                confidence="high",
+            )
             mock_config.create_pipeline.return_value = mock_pipeline
             mock_validate.return_value = mock_config
 
@@ -993,7 +1260,13 @@ class TestIntegration:
                 PipelineEvaluationResult(
                     filename="test.mp4",
                     classification=ResultClassification.CORRECT,
-                    raw_result="otter",
+                    result=RichResult(
+                        is_animal_present=True,
+                        is_animal_unknown=False,
+                        defining_features="test",
+                        species_name="otter",
+                        confidence=ConfidenceLevel.HIGH,
+                    ),
                     label="otter",
                     comparison_method="exact",
                     processing_time_seconds=1.5,


### PR DESCRIPTION
This PR simplifies the AI pipeline results by removing generic response types and replacing them with a unified RichResult model. It updates the VerifiedImageBatchQuery and pipeline evaluation logic to use this more detailed result format, improving consistency and reducing complexity in result handling.