### PR TITLE
fix pr create command body

### DIFF
--- a/.github/workflows/automation-fix.yml
+++ b/.github/workflows/automation-fix.yml
@@ -339,6 +339,7 @@ jobs:
             --base main \
             --head "$BRANCH_NAME" \
             --title "🤖 Automation: $ISSUE_TITLE" \
+            --body '' \
             --label "automation" || echo "Warning: Could not apply automation label")
 
           echo "Created PR $PR_NUMBER for issue #$ISSUE_NUMBER"


### PR DESCRIPTION
**Summary**: This PR updates the automation workflow to ensure that PRs created by the automation process have an explicit empty body, preventing potential default text or missing description issues when the PR is generated.

**Changes**:
- Updated `.github/workflows/automation-fix.yml` to include the `--body ''` flag when creating pull requests.

**Testing**:
- Verified that the GitHub CLI command for PR creation now explicitly sets an empty body.