### PR TITLE
Make sure branchname exists

### DIFF
--- a/.github/workflows/automation-fix.yml
+++ b/.github/workflows/automation-fix.yml
@@ -356,7 +356,11 @@ jobs:
 
       - name: Push branch to remote
         if: steps.find-issue.outputs.issue_found == 'true'
+        env:
+          ISSUE_NUMBER: ${{ steps.find-issue.outputs.issue_number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH_NAME="automated/issue-$ISSUE_NUMBER"
           git push -u origin "$BRANCH_NAME"
 
       - name: Create PR for issue


### PR DESCRIPTION
**Summary**: This PR ensures that the `automation-fix` workflow correctly identifies and uses the specific issue number when pushing the automated fix branch to the remote repository.

**Changes**:
- Added `ISSUE_NUMBER` and `GH_TOKEN` environment variables to the "Push branch to remote" step.
- Updated the git push command to use a structured branch naming convention: `automated/issue-$ISSUE_NUMBER`.

**Testing**:
- Verification is performed via the GitHub Actions workflow execution to ensure branches are created with the correct naming convention and pushed successfully.

**Related Issues**:
- Linked to the issue identified by the `find-issue` step in the workflow.