### PR TITLE
Add watch debug and clip segment trimming

### DIFF
--- a/samples/evaluate.py
+++ b/samples/evaluate.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Evaluate motion detection parameters against synthetic videos.
+
+Runs motion detection on synthetic videos with known ground truth and compares
+detected motion windows against expected motion periods.
+
+Usage:
+    uv run python samples/evaluate.py [OPTIONS]
+"""
+
+import json
+import logging
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+class VideoMetadata(BaseModel):
+    video_path: str
+    area_proportion: float
+    grey: float
+    fps: int
+    width: int
+    height: int
+    padding_frames: int
+    motion_frames: int
+    total_frames: int
+    motion_start_frame: int
+    motion_end_frame: int
+    duration_still_seconds: float
+    duration_motion_seconds: float
+    repeats: int
+
+
+class MotionWindowResult(BaseModel):
+    start_frame: int
+    end_frame: int
+    start_time: str | None = None
+    end_time: str | None = None
+
+
+class EvaluationResult(BaseModel):
+    video_name: str
+    video_path: str
+    threshold: int
+    kernel_size: float
+    scale: float
+    fps: float
+    history: int
+    green_to_amber_motion_min: float
+    detection_rate: float
+    false_positive_rate: float
+    motion_proportion_mean: float
+    motion_proportion_std: float
+    state_transition_latency_frames: int | None
+    motion_windows_detected: int
+    motion_windows: list[MotionWindowResult]
+    output_json_files: list[str]
+    evaluation_time: str
+    processing_duration_seconds: float
+
+
+@dataclass
+class ParameterGrid:
+    thresholds: list[int]
+    kernel_sizes: list[float]
+    scale: float = 0.25
+    fps: float = 5.0
+    history: int = 30
+    green_to_amber_motion_min: float = 0.01
+
+
+def load_metadata(metadata_path: Path) -> VideoMetadata | None:
+    if not metadata_path.exists():
+        logger.warning("Metadata file not found: %s", metadata_path)
+        return None
+    try:
+        with open(metadata_path, encoding="utf-8") as f:
+            data = json.load(f)
+        return VideoMetadata(**data)
+    except (json.JSONDecodeError, KeyError):
+        logger.exception("Failed to parse metadata %s", metadata_path)
+        return None
+
+
+def run_motion_detection(
+    video_path: Path,
+    params: dict[str, Any],
+    temp_dir: Path,
+) -> list[Path]:
+    segments_dir = temp_dir / "segments"
+    output_dir = temp_dir / "output"
+    segments_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "uv",
+        "run",
+        "wildcamtools",
+        "watch",
+        str(video_path),
+        str(segments_dir),
+        str(output_dir),
+        "--threshold",
+        str(params["threshold"]),
+        "--kernel-size",
+        str(params["kernel_size"]),
+        "--scale",
+        str(params["scale"]),
+        "--fps",
+        str(params["fps"]),
+        "--history",
+        str(params["history"]),
+        "--green-to-amber-motion-min",
+        str(params["green_to_amber_motion_min"]),
+        "--offset-start",
+        "0",
+        "--offset-end",
+        "0",
+        "--keep-count",
+        "100",
+        "--segment-duration",
+        "5",
+    ]
+
+    logger.info("Running: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)  # noqa: S603
+
+    if result.returncode != 0:
+        logger.error("Motion detection failed with exit code %d", result.returncode)
+        logger.error("Command: %s", " ".join(cmd))
+        logger.error("Stderr: %s", result.stderr)
+        raise RuntimeError(f"Motion detection failed with exit code {result.returncode}: {result.stderr}")
+
+    output_jsons = sorted(output_dir.glob("*.json"))
+    return output_jsons
+
+
+def parse_output_jsons(json_paths: list[Path]) -> tuple[list[MotionWindowResult], list[float]]:
+    motion_windows: list[MotionWindowResult] = []
+    motion_proportions: list[float] = []
+
+    for json_path in json_paths:
+        try:
+            with open(json_path, encoding="utf-8") as f:
+                data = json.load(f)
+
+            window = MotionWindowResult(
+                start_frame=data.get("start_frame", 0),
+                end_frame=data.get("end_frame", 0),
+                start_time=data.get("start_time"),
+                end_time=data.get("end_time"),
+            )
+            motion_windows.append(window)
+
+            if "motion_window" in data:
+                mw = data["motion_window"]
+                if "transition_window_metrics" in mw:
+                    for _state, metrics in mw["transition_window_metrics"].items():
+                        if "mean" in metrics:
+                            motion_proportions.append(metrics["mean"])
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            logger.warning("Failed to parse output JSON %s: %s", json_path, e)
+
+    return motion_windows, motion_proportions
+
+
+def evaluate_detection(
+    metadata: VideoMetadata,
+    motion_windows: list[MotionWindowResult],
+    motion_proportions: list[float],
+) -> dict[str, Any]:
+    motion_start = metadata.motion_start_frame
+    motion_end = metadata.motion_end_frame
+    still_end = metadata.motion_start_frame - 1
+
+    total_motion_frames = motion_end - motion_start + 1
+    detected_motion_frames = 0
+    false_positive_frames = 0
+
+    for window in motion_windows:
+        overlap_start = max(window.start_frame, motion_start)
+        overlap_end = min(window.end_frame, motion_end)
+        if overlap_end >= overlap_start:
+            detected_motion_frames += overlap_end - overlap_start + 1
+
+        fp_start = max(window.start_frame, 0)
+        fp_end = min(window.end_frame, still_end)
+        if fp_end >= fp_start:
+            false_positive_frames += fp_end - fp_start + 1
+
+    detection_rate = detected_motion_frames / total_motion_frames if total_motion_frames > 0 else 0.0
+    total_still_frames = still_end + 1
+    false_positive_rate = false_positive_frames / total_still_frames if total_still_frames > 0 else 0.0
+
+    motion_proportion_mean = sum(motion_proportions) / len(motion_proportions) if motion_proportions else 0.0
+
+    if len(motion_proportions) > 1:
+        mean = motion_proportion_mean
+        variance = sum((p - mean) ** 2 for p in motion_proportions) / len(motion_proportions)
+        motion_proportion_std = variance**0.5
+    else:
+        motion_proportion_std = 0.0
+
+    min_latency = None
+    for window in motion_windows:
+        if window.start_frame >= motion_start:
+            latency = window.start_frame - motion_start
+            if min_latency is None or latency < min_latency:
+                min_latency = latency
+
+    return {
+        "detection_rate": detection_rate,
+        "false_positive_rate": false_positive_rate,
+        "motion_proportion_mean": motion_proportion_mean,
+        "motion_proportion_std": motion_proportion_std,
+        "state_transition_latency_frames": min_latency,
+        "motion_windows_detected": len(motion_windows),
+    }
+
+
+def evaluate_video(
+    video_path: Path,
+    metadata: VideoMetadata,
+    params: dict[str, Any],
+) -> EvaluationResult | None:
+    logger.info(
+        "Evaluating %s with threshold=%d, kernel_size=%.4f",
+        video_path.name,
+        params["threshold"],
+        params["kernel_size"],
+    )
+
+    start_time = datetime.now()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_path = Path(tmpdir)
+        output_jsons = run_motion_detection(video_path, params, temp_path)
+
+        if not output_jsons:
+            logger.warning("No output generated for %s", video_path.name)
+            return None
+
+        motion_windows, motion_proportions = parse_output_jsons(output_jsons)
+
+        metrics = evaluate_detection(metadata, motion_windows, motion_proportions)
+
+    end_time = datetime.now()
+    processing_duration = (end_time - start_time).total_seconds()
+
+    result = EvaluationResult(
+        video_name=video_path.name,
+        video_path=str(video_path),
+        threshold=params["threshold"],
+        kernel_size=params["kernel_size"],
+        scale=params["scale"],
+        fps=params["fps"],
+        history=params["history"],
+        green_to_amber_motion_min=params["green_to_amber_motion_min"],
+        detection_rate=metrics["detection_rate"],
+        false_positive_rate=metrics["false_positive_rate"],
+        motion_proportion_mean=metrics["motion_proportion_mean"],
+        motion_proportion_std=metrics["motion_proportion_std"],
+        state_transition_latency_frames=metrics["state_transition_latency_frames"],
+        motion_windows_detected=metrics["motion_windows_detected"],
+        motion_windows=motion_windows,
+        output_json_files=[str(p) for p in output_jsons],
+        evaluation_time=start_time.isoformat(),
+        processing_duration_seconds=processing_duration,
+    )
+
+    return result
+
+
+@app.command()
+def main(
+    videos_dir: Annotated[Path, typer.Argument(help="Directory containing synthetic videos")] = Path("samples/synth"),
+    output_dir: Annotated[Path, typer.Argument(help="Output directory for evaluation results")] = Path(
+        "samples/eval_results",
+    ),
+    thresholds: Annotated[
+        list[int] | None,
+        typer.Option("--threshold", "-t", help="Motion threshold values to test"),
+    ] = None,
+    kernel_sizes: Annotated[
+        list[float] | None,
+        typer.Option("--kernel-size", "-k", help="Kernel size values to test"),
+    ] = None,
+    scale: Annotated[float, typer.Option("--scale", "-s", help="Scale factor")] = 0.25,
+    fps: Annotated[float, typer.Option("--fps", "-f", help="FPS")] = 5.0,
+    history: Annotated[int, typer.Option("--history", "-h", help="History frames")] = 30,
+    green_to_amber_motion_min: Annotated[
+        float,
+        typer.Option("--green-to-amber", "-g", help="Green to amber threshold"),
+    ] = 0.01,
+) -> None:
+    """Evaluate motion detection parameters against synthetic videos."""
+    if thresholds is None:
+        thresholds = [8, 16, 32]
+    if kernel_sizes is None:
+        kernel_sizes = [0.001, 0.005, 0.01]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    video_paths = sorted(videos_dir.glob("*.mp4"))
+    if not video_paths:
+        logger.error("No video files found in %s", videos_dir)
+        raise typer.Exit(1)
+
+    logger.info("Found %d videos to evaluate", len(video_paths))
+
+    results: list[EvaluationResult] = []
+    param_grid = ParameterGrid(
+        thresholds=thresholds,
+        kernel_sizes=kernel_sizes,
+        scale=scale,
+        fps=fps,
+        history=history,
+        green_to_amber_motion_min=green_to_amber_motion_min,
+    )
+
+    for video_path in video_paths:
+        metadata_path = video_path.with_suffix(".json")
+        metadata = load_metadata(metadata_path)
+
+        if metadata is None:
+            logger.warning("Skipping %s: no metadata found", video_path.name)
+            continue
+
+        for threshold in param_grid.thresholds:
+            for kernel_size in param_grid.kernel_sizes:
+                params = {
+                    "threshold": threshold,
+                    "kernel_size": kernel_size,
+                    "scale": param_grid.scale,
+                    "fps": param_grid.fps,
+                    "history": param_grid.history,
+                    "green_to_amber_motion_min": param_grid.green_to_amber_motion_min,
+                }
+
+                result = evaluate_video(video_path, metadata, params)
+                if result:
+                    results.append(result)
+                    logger.info(
+                        "Completed %s: %.2fs (detection=%.2f%%, fp=%.2f%%)",
+                        video_path.name,
+                        result.processing_duration_seconds,
+                        result.detection_rate * 100,
+                        result.false_positive_rate * 100,
+                    )
+
+    summary = {
+        "evaluation_summary": {
+            "total_videos": len(video_paths),
+            "videos_with_metadata": len([v for v in video_paths if v.with_suffix(".json").exists()]),
+            "parameter_combinations": len(param_grid.thresholds) * len(param_grid.kernel_sizes),
+            "total_evaluations": len(results),
+            "evaluation_time": datetime.now().isoformat(),
+            "parameters": {
+                "thresholds": param_grid.thresholds,
+                "kernel_sizes": param_grid.kernel_sizes,
+                "scale": param_grid.scale,
+                "fps": param_grid.fps,
+                "history": param_grid.history,
+                "green_to_amber_motion_min": param_grid.green_to_amber_motion_min,
+            },
+        },
+        "results": [r.model_dump() for r in results],
+    }
+
+    output_file = output_dir / "evaluation_results.json"
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    logger.info("Evaluation complete. Results saved to %s", output_file)
+    logger.info("Total evaluations: %d", len(results))
+
+    if results:
+        avg_detection = sum(r.detection_rate for r in results) / len(results)
+        avg_fp = sum(r.false_positive_rate for r in results) / len(results)
+        logger.info("Average detection rate: %.2f%%", avg_detection * 100)
+        logger.info("Average false positive rate: %.2f%%", avg_fp * 100)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/wildcamtools/cli/ai.py
+++ b/src/wildcamtools/cli/ai.py
@@ -52,7 +52,11 @@ def run(
 
 
 def _validate_run_evaluate_inputs(
-    config: Path, labels: Path, video_dir: Path | None, max_workers: int | None, comparison_config: Path
+    config: Path,
+    labels: Path,
+    video_dir: Path | None,
+    max_workers: int | None,
+    comparison_config: Path,
 ) -> None:
     """Validate inputs for run_evaluate command."""
     if not config.exists():
@@ -88,11 +92,13 @@ def _validate_run_evaluate_inputs(
 def run_evaluate(
     config: Annotated[Path, typer.Argument(metavar="CONFIG", help="Path to JSON configuration file")],
     comparison_config_path: Annotated[
-        Path, typer.Argument(metavar="COMPARISON_CONFIG", help="JSON config for label comparison")
+        Path,
+        typer.Argument(metavar="COMPARISON_CONFIG", help="JSON config for label comparison"),
     ],
     labels: Annotated[Path, typer.Argument(metavar="LABELS", help="Path to JSONL labels file")],
     video_dir: Annotated[
-        Path | None, typer.Option("-v", "--video-dir", help="Video directory (defaults to labels parent)")
+        Path | None,
+        typer.Option("-v", "--video-dir", help="Video directory (defaults to labels parent)"),
     ] = None,
     max_workers: Annotated[int | None, typer.Option("-w", "--max-workers", help="Maximum worker processes")] = None,
     output: Annotated[
@@ -186,7 +192,8 @@ def run_batch(
     video_dir: Annotated[Path, typer.Argument(metavar="VIDEO_DIR", help="Directory containing video files")],
     output_dir: Annotated[Path, typer.Argument(metavar="OUTPUT_DIR", help="Directory for JSON output files")],
     max_workers: Annotated[
-        int | None, typer.Option("-w", "--max-workers", help="Maximum worker processes (default: CPU count)")
+        int | None,
+        typer.Option("-w", "--max-workers", help="Maximum worker processes (default: CPU count)"),
     ] = None,
     recursive: Annotated[bool, typer.Option("-r", "--recursive", help="Search recursively for video files")] = True,
     overwrite: Annotated[bool, typer.Option("--overwrite", help="Overwrite existing output files")] = False,
@@ -201,6 +208,7 @@ def run_batch(
 
     Example:
         wildcamtools ai run-batch config.json wildlife/ results/ --max-workers 4
+
     """
     _validate_run_batch_inputs(config, video_dir, output_dir, max_workers)
 

--- a/src/wildcamtools/cli/db.py
+++ b/src/wildcamtools/cli/db.py
@@ -40,6 +40,7 @@ def _find_matching_pairs(video_dir: Path, result_dir: Path) -> tuple[list[tuple[
         - matches: list of (video_path, result_path) tuples
         - video_warnings: list of warning messages for videos without results
         - result_warnings: list of warning messages for results without videos
+
     """
     video_files = set()
     result_files = set()
@@ -67,7 +68,7 @@ def _find_matching_pairs(video_dir: Path, result_dir: Path) -> tuple[list[tuple[
         expected_video_path = rel_result_path.with_suffix(".mp4")
         if expected_video_path not in video_files:
             result_warnings.append(
-                f"Warning: No matching video file for result: {rel_result_path} (expected: {expected_video_path})"
+                f"Warning: No matching video file for result: {rel_result_path} (expected: {expected_video_path})",
             )
 
     return matches, video_warnings, result_warnings
@@ -126,7 +127,10 @@ def _import_single_result(
 
 
 def _import_single_file_mode(
-    input_path: Path, video_path: Path, database: Path, filename_date_format: str | None
+    input_path: Path,
+    video_path: Path,
+    database: Path,
+    filename_date_format: str | None,
 ) -> None:
     """Handle single file import mode."""
     if not input_path.is_file():
@@ -214,7 +218,8 @@ def import_result(
         ),
     ],
     database: Annotated[
-        Path, typer.Option("-d", "--database", help="SQLite database path (default: wildcamtools.db)")
+        Path,
+        typer.Option("-d", "--database", help="SQLite database path (default: wildcamtools.db)"),
     ] = Path("wildcamtools.db"),
     filename_date_format: Annotated[
         str | None,

--- a/src/wildcamtools/cli/watch.py
+++ b/src/wildcamtools/cli/watch.py
@@ -14,7 +14,7 @@ from typing import Annotated
 import typer
 from pydantic import BaseModel
 
-from wildcamtools.lib.concat import concat_videos
+from wildcamtools.lib.concat import SegmentInfo, concat_videos
 from wildcamtools.lib.errors import (
     CannotCombineOpenWindowError,
     MotionMaskNotExistsError,
@@ -36,7 +36,10 @@ logger = logging.getLogger(__name__)
 
 
 def find_segments_for_framerange(
-    start_frame: int, end_frame: int, segments_dir: Path, is_segmenting: bool = True
+    start_frame: int,
+    end_frame: int,
+    segments_dir: Path,
+    is_segmenting: bool = True,
 ) -> tuple[Path, ...] | None:
     """Find segment files that overlap with the given frame range.
 
@@ -49,6 +52,7 @@ def find_segments_for_framerange(
 
     Returns:
         Tuple of segment file paths to merge, or None if not all segments are ready
+
     """
     logger.info("Finding segments for frames %d to %d", start_frame, end_frame)
 
@@ -112,6 +116,7 @@ class ClipMetadata(BaseModel):
         start_time: Start timestamp (for streams)
         end_time: End timestamp (for streams)
         motion_window: Original motion window that triggered the clip
+
     """
 
     start_frame: int
@@ -127,6 +132,7 @@ class OutputClipMetadata(BaseModel):
     Attributes:
         clip: Clip-specific metadata
         config: Configuration used for motion detection (for traceability)
+
     """
 
     clip: ClipMetadata
@@ -138,6 +144,7 @@ class WatcherManager:
     segments_dir: Path
     output_dir: Path
     hwaccel: str
+    debug_video_path: Path | None
     msg_queue: Queue
     state: WatcherManagerStateEnum
     motion_process: MotionProcessWrapper | None
@@ -154,11 +161,13 @@ class WatcherManager:
         segments_dir: Path,
         output_dir: Path,
         hwaccel: str = "",
+        debug_video_path: Path | None = None,
     ) -> None:
         self.config = config
         self.segments_dir = segments_dir
         self.output_dir = output_dir
         self.hwaccel = hwaccel
+        self.debug_video_path = debug_video_path
         self._is_stream = is_stream_url(config.rtsp_stream)
 
         self.msg_queue = Queue()
@@ -181,6 +190,7 @@ class WatcherManager:
             config=self.config,
             restart_on_exit=None,  # Auto-detect
             hwaccel=self.hwaccel,
+            debug_video_path=self.debug_video_path,
         )
         self._motion_process_completed = False
 
@@ -229,6 +239,7 @@ class WatcherManager:
                 config=self.config,
                 restart_on_exit=None,  # Auto-detect
                 hwaccel=self.hwaccel,
+                debug_video_path=self.debug_video_path,
             )
 
         # check and create segment process
@@ -237,7 +248,8 @@ class WatcherManager:
 
             if self.segment_process.returncode != 0:
                 logger.error(
-                    "Segmentation process terminated with error (returncode %d)", self.segment_process.returncode
+                    "Segmentation process terminated with error (returncode %d)",
+                    self.segment_process.returncode,
                 )
                 should_restart = False
 
@@ -272,15 +284,32 @@ class WatcherManager:
         """Convert seconds to frame count."""
         return int(seconds * fps)
 
+    def _build_segment_infos(self, to_merge: tuple[Path, ...]) -> list[SegmentInfo]:
+        """Build segment metadata for accurate trim calculation."""
+        segment_infos: list[SegmentInfo] = []
+        for seg_path in to_merge:
+            meta_path = SegmentMetadata.get_metadata_path(seg_path)
+            meta = SegmentMetadata.load(meta_path)
+            if meta:
+                segment_infos.append(
+                    SegmentInfo(
+                        path=seg_path,
+                        start_frame=meta.start_frame,
+                        end_frame=meta.end_frame,
+                        fps=meta.fps,
+                        duration=meta.duration,
+                        actual_frames=meta.actual_frames,
+                    )
+                )
+        return segment_infos
+
     def combine_segments(self, motion_window: MotionWindow) -> None:
         if motion_window.end_frame is None:
             raise CannotCombineOpenWindowError()
 
-        # Get FPS from the first available segment metadata or use default
-        fps = self._get_fps_from_segments()
-        if fps is None:
-            logger.warning("Could not determine FPS, using default 30.0")
-            fps = 30.0
+        # Use source FPS from motion window for offset calculations
+        # This ensures offsets are calculated in source video frame indices
+        fps = motion_window.source_fps
 
         # Convert offsets from seconds to frames for segment selection
         offset_start_frames = self._seconds_to_frames(self.config.offset_start, fps)
@@ -342,8 +371,25 @@ class WatcherManager:
         )
 
         output_file = self.output_dir / f"{output_base}.mp4"
-        logger.info("Joining %s segments into %s", len(to_merge), output_file)
-        concat_videos(to_merge, output_file)
+        logger.info(
+            "Joining %s segments into %s (trimming to frames %d-%d)",
+            len(to_merge),
+            output_file,
+            segment_start_frame,
+            segment_end_frame,
+        )
+
+        # Build segment metadata for accurate trim calculation
+        segment_infos = self._build_segment_infos(to_merge)
+
+        concat_videos(
+            to_merge,
+            output_file,
+            trim_start_frame=segment_start_frame,
+            trim_end_frame=segment_end_frame,
+            source_fps=fps,
+            segment_metadata=segment_infos,
+        )
 
         # also output a JSON summary
         with open(self.output_dir / f"{output_base}.json", "w") as json_out:
@@ -436,6 +482,7 @@ def generate_config_cmd(
 
     Args:
         output: Output file path (defaults to watch_config.json in current directory)
+
     """
     if output is None:
         output = Path("watch_config.json")
@@ -447,13 +494,22 @@ def generate_config_cmd(
 
 
 @app.command()
-def watch(
+def watch(  # noqa: C901
     config: Annotated[Path, typer.Argument(metavar="CONFIG", help="Path to JSON configuration file")],
     segments: Annotated[Path, typer.Argument(metavar="SEGMENTS", help="Directory for segment files")],
     output: Annotated[Path, typer.Argument(metavar="OUTPUT", help="Directory for output clips")],
     hwaccel: Annotated[
-        str, typer.Option(metavar="STR", envvar="WCT_HWACCEL", help="Hardware acceleration method")
+        str,
+        typer.Option(metavar="STR", envvar="WCT_HWACCEL", help="Hardware acceleration method"),
     ] = "",
+    debug_video: Annotated[
+        Path | None,
+        typer.Option(
+            metavar="PATH",
+            envvar="WCT_DEBUG_VIDEO",
+            help="Path to write debug video output (1:1 frames with overlays)",
+        ),
+    ] = None,
 ) -> None:
     """Watch a video stream and generate motion-detected clips.
 
@@ -466,6 +522,8 @@ def watch(
         segments: Directory for segment files (must exist)
         output: Directory for output clips (must exist)
         hwaccel: Hardware acceleration method (see https://trac.ffmpeg.org/wiki/HWAccelIntro)
+        debug_video: Optional path to write debug video output
+
     """
     if not config.exists():
         typer.secho(f"Error: Config file not found: {config}", err=True)
@@ -483,6 +541,12 @@ def watch(
     if not output.is_dir() or not output.exists():
         typer.secho(f"Error: Output directory does not exist: {output}", err=True)
         raise typer.Exit(code=1)
+
+    if debug_video:
+        debug_video = debug_video.resolve()
+        if not debug_video.parent.exists():
+            typer.secho(f"Error: Debug video parent directory does not exist: {debug_video.parent}", err=True)
+            raise typer.Exit(code=1)
 
     logger.info("Loading config from %s", config)
     watch_config = WatchConfig.from_json(config)
@@ -502,6 +566,7 @@ def watch(
         segments_dir=segments,
         output_dir=output,
         hwaccel=hwaccel,
+        debug_video_path=debug_video,
     )
     watcher.run()
 

--- a/src/wildcamtools/lib/ai/batch_processing.py
+++ b/src/wildcamtools/lib/ai/batch_processing.py
@@ -41,7 +41,8 @@ class BatchWorkerResult(BaseModel):
 
 
 def _build_combined_output[R: BaseModel](
-    outcome: PipelineOutcome[R] | CombinedPipelineOutcome[R], config: AiPipelineConfig
+    outcome: PipelineOutcome[R] | CombinedPipelineOutcome[R],
+    config: AiPipelineConfig,
 ) -> BatchPipelineOutput[R]:
     return BatchPipelineOutput[R](config=config, outcome=outcome)
 
@@ -60,6 +61,7 @@ def _run_pipeline_worker(
 
     Returns:
         BatchWorkerResult with processing details
+
     """
     video_path = Path(video_path_str)
     output_path = Path(output_path_str)
@@ -108,6 +110,7 @@ def discover_video_files(video_dir: Path, recursive: bool = True) -> list[Path]:
 
     Returns:
         List of video file paths sorted by path
+
     """
     patterns = ["*.mp4", "*.MP4"]
     video_files: list[Path] = []
@@ -132,6 +135,7 @@ def compute_output_path(video_path: Path, video_dir: Path, output_dir: Path) -> 
 
     Returns:
         Path to the output JSON file
+
     """
     try:
         relative_path = video_path.relative_to(video_dir)
@@ -164,6 +168,7 @@ def run_batch_pipeline(
 
     Returns:
         List of BatchWorkerResult objects
+
     """
     # Filter out videos that already have output files
     pending_videos: list[tuple[Path, Path]] = []

--- a/src/wildcamtools/lib/ai/label_comparison.py
+++ b/src/wildcamtools/lib/ai/label_comparison.py
@@ -28,6 +28,7 @@ class AbstractLabelComparator(ABC):
 
         Returns:
             Classification if a special case is detected, None otherwise.
+
         """
         result_lower = result.lower()
         label_lower = label.lower()
@@ -38,8 +39,7 @@ class AbstractLabelComparator(ABC):
         if result_lower in ABSENCE_MARKERS:
             if label_lower in ABSENCE_MARKERS:
                 return ResultClassification.CORRECT
-            else:
-                return ResultClassification.INCORRECT
+            return ResultClassification.INCORRECT
 
         if result_lower == label_lower:
             return ResultClassification.CORRECT
@@ -57,6 +57,7 @@ class AbstractLabelComparator(ABC):
         Returns:
             The classification type (correct, incorrect, unknown).
             The correctness can be inferred from the classification value.
+
         """
         ...
 
@@ -80,8 +81,7 @@ class ExactLabelComparator(AbstractLabelComparator):
         if not result.is_animal_present:
             if label.lower() in ABSENCE_MARKERS:
                 return ResultClassification.CORRECT
-            else:
-                return ResultClassification.INCORRECT
+            return ResultClassification.INCORRECT
 
         special_case = self._check_special_cases(result.species_name, label)
         if special_case is not None:
@@ -100,11 +100,13 @@ class LLMLabelComparator(AbstractLabelComparator):
 
     Uses an LLM to determine if a result semantically matches a label.
     The rule is: result can be a subset/specific instance of label, but not vice versa.
+
     Examples:
         - "domestic cat" vs "cat" → True (specific instance)
         - "Moorhen" vs "bird" → True (specific instance)
         - "cat" vs "domestic cat" → False (too general)
         - "animal" vs "cat" → False (too general)
+
     """
 
     _cache: dict[tuple[str, str], ResultClassification] | None
@@ -144,8 +146,7 @@ class LLMLabelComparator(AbstractLabelComparator):
         if not result.is_animal_present:
             if label_lower in ABSENCE_MARKERS:
                 return ResultClassification.CORRECT
-            else:
-                return ResultClassification.INCORRECT
+            return ResultClassification.INCORRECT
 
         special_case = self._check_special_cases(result_lower, label_lower)
         if special_case is not None:

--- a/src/wildcamtools/lib/ai/label_comparison_config.py
+++ b/src/wildcamtools/lib/ai/label_comparison_config.py
@@ -42,6 +42,7 @@ class LabelComparisonConfig(BaseModel):
             "cache_enabled": true
         }
         ```
+
     """
 
     comparator_type: LabelComparisonType = LabelComparisonType.EXACT
@@ -75,6 +76,7 @@ class LabelComparisonConfig(BaseModel):
         Raises:
             ValueError: If comparator_type is 'llm' but no LLM config is provided.
             NotImplementedError: If the comparator_type is not supported.
+
         """
         match self.comparator_type:
             case LabelComparisonType.EXACT:
@@ -84,7 +86,7 @@ class LabelComparisonConfig(BaseModel):
                 if self.llm is None:
                     raise ValueError(
                         "LLM configuration is required when comparator_type is 'llm'. "
-                        "Please provide 'llm' configuration in the label comparison config."
+                        "Please provide 'llm' configuration in the label comparison config.",
                     )
 
                 llm_instance = self.llm.create_llm()

--- a/src/wildcamtools/lib/ai/llm/__init__.py
+++ b/src/wildcamtools/lib/ai/llm/__init__.py
@@ -23,6 +23,7 @@ def create_analyser(
 
     Raises:
         NotImplementedError: If the backend is not supported.
+
     """
     match backend:
         case Backend.LLAMACPP:

--- a/src/wildcamtools/lib/ai/llm/llamacpp.py
+++ b/src/wildcamtools/lib/ai/llm/llamacpp.py
@@ -54,7 +54,7 @@ class LlamaCppLlm(AbstractLlm):
             {
                 "type": "text",
                 "text": message,
-            }
+            },
         ]
 
         for image_base64 in image_bytes:

--- a/src/wildcamtools/lib/ai/parallel_processing.py
+++ b/src/wildcamtools/lib/ai/parallel_processing.py
@@ -26,6 +26,7 @@ def time_pipeline_execution(
 
     Raises:
         Exception: Any exception from pipeline execution is propagated
+
     """
     start_time = time.time()
     pipeline = pipeline_config.create_pipeline()
@@ -51,6 +52,7 @@ def run_parallel_worker_pool(
 
     Returns:
         List of results from worker_fn (excludes failed tasks)
+
     """
     ctx = multiprocessing.get_context("spawn")
     results: list[Any] = []
@@ -97,6 +99,7 @@ def run_parallel_worker_pool_with_labels(
 
     Returns:
         List of (label, result) tuples (excludes failed tasks)
+
     """
     ctx = multiprocessing.get_context("spawn")
     results: list[tuple[Any, Any]] = []
@@ -144,6 +147,7 @@ def validate_evaluation_paths(
     Raises:
         FileNotFoundError: If a required path doesn't exist
         ValueError: If a path is not the correct type (file vs directory)
+
     """
     if not config_path.exists():
         raise FileNotFoundError(f"Config file not found: {config_path}")

--- a/src/wildcamtools/lib/ai/pipeline.py
+++ b/src/wildcamtools/lib/ai/pipeline.py
@@ -41,6 +41,7 @@ class ExtractedFrame(BaseModel):
     Attributes:
         path: Path to the image file (excluded from JSON serialization, optional for deserialization)
         frame_no: Frame number (included in JSON serialization)
+
     """
 
     path: Path | None = Field(exclude=True, default=None)
@@ -57,11 +58,12 @@ class ExtractedFrame(BaseModel):
 
         Raises:
             ValueError: If path is None
+
         """
         if self.path is None:
             raise ValueError(
                 f"ExtractedFrame.path is required but is None for frame_no={self.frame_no}. "
-                "This indicates a bug in the pipeline execution."
+                "This indicates a bug in the pipeline execution.",
             )
         return self.path
 
@@ -71,6 +73,7 @@ class ExtractedBatch(BaseModel):
 
     Attributes:
         frame_image_pairs: List of FrameImagePair objects (atomic pairing)
+
     """
 
     selected_frames: list[ExtractedFrame]
@@ -82,6 +85,7 @@ class BatchResult[R: BaseModel](ExtractedBatch):
     Attributes:
         frame_image_pairs: List of FrameImagePair (inherited)
         result: RichResult from AI analysis (None before processing)
+
     """
 
     result: R | None = None
@@ -110,6 +114,7 @@ class ExtractedFrames(BaseModel):
 
     Attributes:
         batches: List of ExtractedBatch objects
+
     """
 
     batches: list[ExtractedBatch]
@@ -134,6 +139,7 @@ class ExtractedFramesWithResults[R: BaseModel](ExtractedFrames):
 
     Attributes:
         batches: List of BatchResult objects (contains results after AI processing)
+
     """
 
     batches: Sequence[BatchResult[R]]  # type: ignore[assignment]
@@ -154,6 +160,7 @@ class PipelineOutcome[R: BaseModel](BaseModel):
         result: The final result from the AI pipeline
         stats: Video statistics captured at the start of processing
         batches: List of BatchResult objects with frames and per-batch AI results
+
     """
 
     result: R
@@ -181,6 +188,7 @@ class CombinedBatchResult(BaseModel):
         selected_frames: List of extracted frames
         classification: RichResult from classification (None if classification not run)
         description: BatchDescription from description (None if description not run)
+
     """
 
     selected_frames: list[ExtractedFrame]
@@ -196,6 +204,7 @@ class CombinedPipelineOutcome[R: BaseModel](BaseModel):
         description: Combined description result (None if description not enabled)
         stats: Video statistics
         batches: List of CombinedBatchResult with both classification and description per batch
+
     """
 
     result: R
@@ -585,7 +594,7 @@ class VerifiedImageBatchQuery[R: BaseModel](ImageBatchQuery[R]):
         logger.debug("Initial classification: %s", getattr(initial_result, "species_name", initial_result))
 
         verification_message = self.verification_prompt.format(
-            initial_species=getattr(initial_result, "species_name", "")
+            initial_species=getattr(initial_result, "species_name", ""),
         )
         verification_result: VerificationResult = self.llm.message_with_schema(
             message=verification_message,
@@ -627,6 +636,7 @@ class RichResultMajorityReconciler(ResultReconciler[RichResult]):
 
     Raises:
         ValueError: If results iterable is empty.
+
     """
 
     def reconcile_results(self, results: Iterable[RichResult]) -> RichResult:
@@ -785,14 +795,16 @@ class AiPipeline[R: BaseModel]:
 
                 combined_batches = []
                 for classification_batch, description_batch in zip(
-                    enriched_frames.batches, description_enriched.batches, strict=True
+                    enriched_frames.batches,
+                    description_enriched.batches,
+                    strict=True,
                 ):
                     combined_batches.append(
                         CombinedBatchResult(
                             selected_frames=classification_batch.selected_frames,
                             classification=classification_batch.result,  # type: ignore[arg-type] # CombinedBatchResult.classification is RichResult|None; classification_batch.result is R|None where R=RichResult in this context
                             description=description_batch.result,
-                        )
+                        ),
                     )
 
                 return CombinedPipelineOutcome[R](

--- a/src/wildcamtools/lib/ai/pipeline_config.py
+++ b/src/wildcamtools/lib/ai/pipeline_config.py
@@ -86,6 +86,7 @@ class FrameSelectorConfig(BaseModel):
 
         Raises:
             NotImplementedError: If the selector_type is not supported.
+
         """
         match self.selector_type:
             case FrameSelectorType.FPS_RESCALING:
@@ -169,6 +170,7 @@ class FrameExtractorConfig(BaseModel):
 
         Raises:
             ValueError: If analyser_llm is not provided for AI_CROPPED extractor type.
+
         """
         match self.extractor_type:
             case FrameExtractorType.RESCALED:
@@ -177,7 +179,7 @@ class FrameExtractorConfig(BaseModel):
                 if analyser_llm is None:
                     if self.analyser is None:
                         raise ValueError(
-                            "analyser_llm must be provided or configured in analyser for AI_CROPPED extractor"
+                            "analyser_llm must be provided or configured in analyser for AI_CROPPED extractor",
                         )
                     analyser_llm = self.analyser.create_llm()
                 aicropfinder = AICropFinder(analyser=analyser_llm, expansion=self.crop_expansion)
@@ -202,7 +204,7 @@ class LlmConfig(BaseModel):
     backend: Backend = Backend.OLLAMA
     model: Annotated[str, Field(strict=True, min_length=1, description="Model name/identifier")]
     url: Annotated[AnyHttpUrl, Field(description="Base URL for the LLM service")] = AnyHttpUrl(
-        "http://localhost:8080/v1"
+        "http://localhost:8080/v1",
     )
     api_key: SecretStr | None = None
 
@@ -223,6 +225,7 @@ class LlmConfig(BaseModel):
 
         Returns:
             AbstractLlm: The configured LLM instance.
+
         """
         return create_analyser(
             backend=self.backend,
@@ -269,7 +272,7 @@ class ImageBatchQueryConfig(BaseModel):
         if self.query_type in (ImageBatchQueryType.LLM, ImageBatchQueryType.VERIFIED) and not self.prompt:
             raise ValueError(
                 f"'prompt' is required when query_type is '{self.query_type.value}'. "
-                "Provide a non-empty 'prompt' in the query config."
+                "Provide a non-empty 'prompt' in the query config.",
             )
         return self
 
@@ -282,6 +285,7 @@ class ImageBatchQueryConfig(BaseModel):
 
         Returns:
             The configured image batch query instance.
+
         """
         llm = self.llm.create_llm()
         match self.query_type:
@@ -335,6 +339,7 @@ class ReconcilerConfig(BaseModel):
 
         Raises:
             NotImplementedError: If the reconciler_type is not supported.
+
         """
         match self.reconciler_type:
             case ReconcilerType.MAJORITY:
@@ -347,7 +352,7 @@ class ReconcilerConfig(BaseModel):
                 else:
                     raise ValueError(
                         "An LLM is required for the description reconciler. "
-                        "Provide one via 'llm' in the reconciler config or as a fallback."
+                        "Provide one via 'llm' in the reconciler config or as a fallback.",
                     )
                 return LlmDescriptionReconciler(
                     llm=reconciler_llm,
@@ -395,8 +400,8 @@ class AiPipelineConfig(BaseModel):
                     "llm": {"backend": "ollama", "model": "gemma4:31b-cloud"},
                     "description_prompt": "Describe what is happening in these frames.",
                 },
-            }
-        }
+            },
+        },
     )
 
     frame_selector: FrameSelectorConfig = Field(default_factory=FrameSelectorConfig)

--- a/src/wildcamtools/lib/ai/pipeline_evaluation.py
+++ b/src/wildcamtools/lib/ai/pipeline_evaluation.py
@@ -158,7 +158,7 @@ def _run_worker_pool(
                 processing_time_seconds=worker_result.processing_time_seconds,
                 frame_ids=worker_result.frame_ids,
                 stats=worker_result.outcome.stats.model_dump(),
-            )
+            ),
         )
 
     return results
@@ -186,6 +186,7 @@ def evaluate_ai_pipeline(
     Raises:
         FileNotFoundError: If config_path, labels_path, or comparison_config_path doesn't exist.
         ValueError: If config_path, labels_path, or comparison_config_path is not a file.
+
     """
     validate_evaluation_paths(config_path, labels_path, video_dir, comparison_config_path)
 

--- a/src/wildcamtools/lib/ai/types.py
+++ b/src/wildcamtools/lib/ai/types.py
@@ -74,7 +74,8 @@ class VerificationResult(BaseModel):
 
 class RichResult(BaseModel):
     is_animal_present: Annotated[
-        bool, Field(description="Flag if any animal is visible in these images.", examples=["true", "false"])
+        bool,
+        Field(description="Flag if any animal is visible in these images.", examples=["true", "false"]),
     ]
     is_animal_unknown: Annotated[
         bool,

--- a/src/wildcamtools/lib/background_process.py
+++ b/src/wildcamtools/lib/background_process.py
@@ -12,11 +12,10 @@ from wildcamtools.lib.errors import (
 
 
 class BackgroundProcess:
-    """
-    Usage:
-        with BackgroundProcess(['myserver', '--flag'], cwd='/path', ready_check=lambda: port_open(8000)):
-            # process is running here
-            do_work()
+    """Usage:
+    with BackgroundProcess(['myserver', '--flag'], cwd='/path', ready_check=lambda: port_open(8000)):
+        # process is running here
+        do_work()
     """
 
     cmd: list[str]

--- a/src/wildcamtools/lib/concat.py
+++ b/src/wildcamtools/lib/concat.py
@@ -1,96 +1,243 @@
 import logging
-import tempfile
 from collections.abc import Iterable
-from contextlib import suppress
 from pathlib import Path
 
 import av
+from pydantic import BaseModel, Field, model_validator
+
+from wildcamtools.lib.vidio import VideoWriter
 
 logger = logging.getLogger(__name__)
 
 
-def _escape_ffconcat_path(path: Path) -> str:
-    """Escape a path for use in ffconcat manifest.
+class SegmentInfo(BaseModel):
+    """Information about a segment for trim calculation.
 
-    FFmpeg concat demuxer requires special characters to be escaped:
-    - Single quotes are doubled ('' becomes '''')
-    - Backslashes are escaped (\\ becomes \\\\)
+    Attributes:
+        path: Path to the segment file
+        start_frame: First frame number in the segment
+        end_frame: Last frame number in the segment
+        fps: Frames per second
+        duration: Actual segment duration in seconds (optional)
+        actual_frames: Actual frame count (optional)
 
-    Args:
-        path: Path to escape
-
-    Returns:
-        Escaped path string safe for ffconcat
-
-    Raises:
-        ValueError: If path contains unsupported characters (newlines, carriage returns)
     """
-    path_str = str(path.resolve())
-    if "\n" in path_str or "\r" in path_str:
-        msg = f"Path contains newline characters which are not supported in ffconcat: {path}"
+
+    path: Path
+    start_frame: int = Field(ge=0)
+    end_frame: int = Field(ge=0)
+    fps: float = Field(gt=0)
+    duration: float | None = Field(default=None, ge=0)
+    actual_frames: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _validate_frame_range(self) -> "SegmentInfo":
+        if self.end_frame < self.start_frame:
+            msg = f"end_frame ({self.end_frame}) must be >= start_frame ({self.start_frame})"
+            raise ValueError(msg)
+        return self
+
+
+def _calculate_concat_frame_range(
+    trim_start_frame: int | None,
+    trim_end_frame: int | None,
+    segment_metadata: list[SegmentInfo],
+) -> tuple[int | None, int | None]:
+    """Map source frame numbers to concatenated video frame positions."""
+    concat_start_frame: int | None = None
+    concat_end_frame: int | None = None
+    cumulative_frames = 0
+
+    for seg in segment_metadata:
+        seg_start_frame_concat = cumulative_frames
+        if seg.actual_frames is not None:
+            seg_frame_count = seg.actual_frames
+        elif seg.duration is not None and seg.duration > 0:
+            seg_frame_count = int(seg.duration * seg.fps + 0.5)
+        else:
+            seg_frame_count = seg.end_frame - seg.start_frame + 1
+
+        if (
+            trim_start_frame is not None
+            and concat_start_frame is None
+            and seg.start_frame <= trim_start_frame <= seg.end_frame
+        ):
+            concat_start_frame = seg_start_frame_concat + (trim_start_frame - seg.start_frame)
+
+        if (
+            trim_end_frame is not None
+            and concat_end_frame is None
+            and seg.start_frame <= trim_end_frame <= seg.end_frame
+        ):
+            concat_end_frame = seg_start_frame_concat + (trim_end_frame - seg.start_frame)
+
+        cumulative_frames += seg_frame_count
+
+    return concat_start_frame, concat_end_frame
+
+
+def _resolve_trim_frames(
+    trim_start_frame: int | None,
+    trim_end_frame: int | None,
+    segment_metadata: list[SegmentInfo] | None,
+) -> tuple[int | None, int | None]:
+    """Resolve trim frame numbers to concatenated video frame positions."""
+    if segment_metadata and (trim_start_frame is not None or trim_end_frame is not None):
+        concat_start_frame, concat_end_frame = _calculate_concat_frame_range(
+            trim_start_frame, trim_end_frame, segment_metadata
+        )
+        if trim_start_frame is not None and concat_start_frame is None:
+            msg = f"Trim start frame {trim_start_frame} not found in any segment metadata"
+            raise ValueError(msg)
+        if trim_end_frame is not None and concat_end_frame is None:
+            msg = f"Trim end frame {trim_end_frame} not found in any segment metadata"
+            raise ValueError(msg)
+        return concat_start_frame, concat_end_frame
+    return trim_start_frame, trim_end_frame
+
+
+def _inspect_first_segment(input_path: Path, source_fps: float | None) -> tuple[float, int, int, bool]:
+    """Open the first segment and extract FPS, resolution, and audio presence."""
+    with av.open(str(input_path)) as container:
+        if not container.streams.video:
+            msg = f"Input file has no video stream: {input_path}"
+            raise ValueError(msg)
+        video_stream = container.streams.video[0]
+        rate = video_stream.average_rate or video_stream.base_rate
+        if rate:
+            fps = round(float(rate), 2)
+        elif source_fps is not None:
+            fps = source_fps
+        else:
+            logger.warning(
+                "Could not detect FPS from segment %s and no source_fps provided, defaulting to 30.0", input_path
+            )
+            fps = 30.0
+        ref_width = video_stream.width
+        ref_height = video_stream.height
+        has_audio = bool(container.streams.audio)
+    return fps, ref_width, ref_height, has_audio
+
+
+def _concat_reencode(  # noqa: C901
+    inputs: list[Path],
+    output_path: Path,
+    trim_start_frame: int | None = None,
+    trim_end_frame: int | None = None,
+    source_fps: float | None = None,
+    segment_metadata: list[SegmentInfo] | None = None,
+) -> None:
+    """Decode all segments frame-by-frame and re-encode using VideoWriter."""
+    if not inputs:
+        msg = "No input files provided"
         raise ValueError(msg)
-    escaped = path_str.replace("\\", "\\\\").replace("'", "''")
-    logger.debug("Escaped path for ffconcat: %s -> %s", path_str, escaped)
-    return escaped
+
+    if trim_start_frame is not None and trim_end_frame is not None and trim_start_frame > trim_end_frame:
+        msg = f"trim_start_frame ({trim_start_frame}) must be <= trim_end_frame ({trim_end_frame})"
+        raise ValueError(msg)
+
+    concat_start_frame, concat_end_frame = _resolve_trim_frames(trim_start_frame, trim_end_frame, segment_metadata)
+
+    fps, ref_width, ref_height, has_audio = _inspect_first_segment(inputs[0], source_fps)
+    if has_audio:
+        logger.warning("Audio tracks in input segments will be dropped (not yet supported)")
+
+    with VideoWriter(output_path, fps=fps) as writer:
+        frame_no = 0
+        written_frames = 0
+        video_done = False
+        for input_path in inputs:
+            if video_done:
+                break
+            logger.debug("Processing segment %s", input_path)
+            with av.open(str(input_path)) as input_container:
+                if not input_container.streams.video:
+                    msg = f"Segment has no video stream: {input_path}"
+                    raise ValueError(msg)
+                in_video = input_container.streams.video[0]
+                if in_video.width != ref_width or in_video.height != ref_height:
+                    msg = (
+                        f"Segment {input_path} resolution {in_video.width}x{in_video.height} "
+                        f"differs from first segment {ref_width}x{ref_height}"
+                    )
+                    raise ValueError(msg)
+                if input_container.streams.audio and not has_audio:
+                    logger.warning("Segment %s has audio but first segment does not; audio will be dropped", input_path)
+
+                for packet in input_container.demux(input_container.streams.video[0]):
+                    try:
+                        decoded_frames = packet.decode()
+                    except av.error.FFmpegError:
+                        logger.warning("Failed to decode packet in segment %s, skipping", input_path)
+                        continue
+                    for frame in decoded_frames:
+                        if isinstance(frame, av.VideoFrame):
+                            if concat_start_frame is not None and frame_no < concat_start_frame:
+                                frame_no += 1
+                                continue
+                            if concat_end_frame is not None and frame_no > concat_end_frame:
+                                video_done = True
+                                break
+
+                            rgb = frame.to_ndarray(format="rgb24")
+                            writer.write(rgb)
+                            frame_no += 1
+                            written_frames += 1
+
+                    if video_done:
+                        break
+
+    logger.debug("Wrote %d frames to %s", written_frames, output_path)
 
 
-def concat_videos(inputs: Iterable[Path], output: Path) -> None:
-    """Concatenate video files using PyAV concat demuxer.
+def concat_videos(
+    inputs: Iterable[Path],
+    output: Path,
+    trim_start_frame: int | None = None,
+    trim_end_frame: int | None = None,
+    source_fps: float | None = None,
+    segment_metadata: list[SegmentInfo] | None = None,
+) -> None:
+    """Concatenate video files using PyAV with optional frame-accurate trimming.
 
-    Uses FFmpeg concat demuxer via PyAV with stream copy (no re-encoding).
+    Decodes all input segments frame-by-frame to numpy arrays and re-encodes
+    them into a single output file using VideoWriter. When trim_start_frame
+    and/or trim_end_frame are specified, only frames within that range are
+    included in the output.
 
     Args:
         inputs: Iterable of input video file paths
         output: Output video file path
+        trim_start_frame: First frame to include (for trimming)
+        trim_end_frame: Last frame to include (for trimming)
+        source_fps: Fallback FPS used when the segment file has no detectable
+            frame rate. Required when trim parameters are provided.
+        segment_metadata: Optional list of segment metadata for accurate trim calculation
 
     Raises:
-        av.error.FFmpegError: If concat operation fails
-        ValueError: If any input path contains unsupported characters
+        ValueError: If trim parameters provided without source_fps, if segments
+            have mismatched resolution, if an input has no video stream, or if
+            trim frames are not found in segment metadata
+
     """
     inputs_list = list(inputs)
     logger.debug("Concatenating %d videos to %s", len(inputs_list), output)
 
-    list_file_path: str | None = None
-    try:
-        with tempfile.NamedTemporaryFile("w+t", suffix=".txt", delete=False) as list_file:
-            list_file.write("ffconcat version 1.0\n")
-            for filename in inputs_list:
-                escaped_path = _escape_ffconcat_path(filename)
-                list_file.write(f"file '{escaped_path}'\n")
-            list_file_path = list_file.name
+    if not inputs_list:
+        logger.warning("No input videos to concatenate")
+        return
 
-        temp_output = output.with_name(output.name + ".tmp")
-        try:
-            with (
-                av.open(
-                    list_file_path,
-                    format="concat",
-                    options={"safe": "0"},
-                ) as container,
-                av.open(temp_output, "w", format=output.suffix.lstrip(".")) as output_container,
-            ):
-                stream_map: dict[int, av.stream.Stream] = {}
-                for in_stream in container.streams:
-                    if in_stream.type not in ("video", "audio"):
-                        logger.debug(
-                            "Skipping non-video/audio stream (type=%s, index=%d)", in_stream.type, in_stream.index
-                        )
-                        continue
-                    stream_map[in_stream.index] = output_container.add_stream_from_template(in_stream)
+    if (trim_start_frame is not None or trim_end_frame is not None) and source_fps is None:
+        msg = "source_fps is required when using trim_start_frame or trim_end_frame"
+        raise ValueError(msg)
 
-                for packet in container.demux():
-                    if packet.dts is None or packet.stream.index not in stream_map:
-                        continue
-                    packet.stream = stream_map[packet.stream.index]
-                    output_container.mux(packet)
+    _concat_reencode(
+        inputs_list,
+        output,
+        trim_start_frame=trim_start_frame,
+        trim_end_frame=trim_end_frame,
+        source_fps=source_fps,
+        segment_metadata=segment_metadata,
+    )
 
-            temp_output.replace(output)
-            logger.debug("Successfully concatenated %d videos", len(inputs_list))
-        except Exception:
-            with suppress(Exception):
-                temp_output.unlink()
-            raise
-    finally:
-        if list_file_path is not None:
-            with suppress(Exception):
-                Path(list_file_path).unlink()
+    logger.debug("Successfully concatenated %d videos", len(inputs_list))

--- a/src/wildcamtools/lib/debug_video.py
+++ b/src/wildcamtools/lib/debug_video.py
@@ -1,0 +1,252 @@
+"""Debug video output handlers for motion detection visualization."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Self
+
+import cv2
+import numpy as np
+
+from wildcamtools.lib import Frame, FrameHandler
+from wildcamtools.lib.motion import MogMotion
+from wildcamtools.lib.vidio import VideoWriter
+
+if TYPE_CHECKING:
+    from wildcamtools.lib.states import Watcher
+
+logger = logging.getLogger(__name__)
+
+
+class DebugVideoOverlay(FrameHandler):
+    """Adds debug overlays to frames showing motion detection state and contours.
+
+    Overlays are drawn on the full-resolution frame (frame.raw), with motion
+    contours scaled up from the motion detection resolution to match.
+    """
+
+    watcher: Watcher
+    motion_handler: MogMotion
+    state_colors: dict[str, tuple[int, int, int]]
+    _contour_scale: tuple[float, float] | None
+
+    def __init__(
+        self,
+        watcher: Watcher,
+        motion_handler: MogMotion,
+    ) -> None:
+        from wildcamtools.lib.states import WatcherStateEnum
+
+        self.watcher = watcher
+        self.motion_handler = motion_handler
+        self.state_colors = {
+            WatcherStateEnum.PREPARING: (128, 128, 128),
+            WatcherStateEnum.GREEN: (0, 255, 0),
+            WatcherStateEnum.AMBER: (255, 195, 0),
+            WatcherStateEnum.RED: (255, 0, 0),
+            WatcherStateEnum.RED_AMBER: (255, 140, 0),
+            WatcherStateEnum.DISABLED: (64, 64, 64),
+        }
+        self._contour_scale = None
+        logger.debug("DebugVideoOverlay initialized for watcher state machine")
+
+    def _contour_scale_cached(self, frame: Frame) -> tuple[float, float]:
+        """Compute and cache contour scale factor.
+
+        Assumes frame resolution is constant throughout the video.
+        The scale factor is computed once on first call and cached.
+        """
+        if self._contour_scale is not None:
+            return self._contour_scale
+
+        self._contour_scale = self._compute_contour_scale(frame)
+        return self._contour_scale
+
+    def _compute_contour_scale(self, frame: Frame) -> tuple[float, float]:
+        """Compute scale factor from motion mask resolution to full frame resolution.
+
+        Returns (1.0, 1.0) if motion mask is not yet available.
+        """
+        if self.motion_handler.motion_mask is None:
+            return (1.0, 1.0)
+
+        mask_h, mask_w = self.motion_handler.motion_mask.shape
+        frame_h, frame_w = frame.raw.shape[:2]
+
+        scale_x = frame_w / mask_w
+        scale_y = frame_h / mask_h
+
+        logger.debug(
+            "Contour scale: mask %dx%d -> frame %dx%d (scale %.2f, %.2f)",
+            mask_w,
+            mask_h,
+            frame_w,
+            frame_h,
+            scale_x,
+            scale_y,
+        )
+
+        return (scale_x, scale_y)
+
+    def _scale_contours(
+        self,
+        contours: list[np.ndarray],
+        scale_x: float,
+        scale_y: float,
+    ) -> list[np.ndarray]:
+        """Scale contour coordinates from motion resolution to full resolution."""
+        scaled_contours: list[np.ndarray] = []
+        for contour in contours:
+            scaled = contour.copy()
+            scaled[:, :, 0] = (scaled[:, :, 0] * scale_x).astype(np.int32)
+            scaled[:, :, 1] = (scaled[:, :, 1] * scale_y).astype(np.int32)
+            scaled_contours.append(scaled)
+        return scaled_contours
+
+    def handle(self, frame: Frame) -> Frame:
+        output = frame.raw.copy()
+        height, width = output.shape[:2]
+        state = self.watcher.state
+        color = self.state_colors.get(state, (128, 128, 128))
+
+        cv2.rectangle(output, (0, 0), (width - 1, height - 1), color, 3)
+
+        text_scale = 0.5
+        text_thickness = 2
+        text_y_base = 50
+        text_spacing = 40
+
+        motion_text = f"Motion: {frame.motion_proportion:.4f}"
+        (text_w, _), _ = cv2.getTextSize(
+            motion_text,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            text_thickness,
+        )
+        cv2.putText(
+            output,
+            motion_text,
+            (width - text_w - 10, text_y_base),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            color,
+            text_thickness,
+            cv2.LINE_AA,
+        )
+
+        frame_number_text = f"Frame: {frame.frame_no:06d}"
+        (text_w, _), _ = cv2.getTextSize(
+            frame_number_text,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            text_thickness,
+        )
+        cv2.putText(
+            output,
+            frame_number_text,
+            (width - text_w - 10, text_y_base + text_spacing),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            color,
+            text_thickness,
+            cv2.LINE_AA,
+        )
+
+        timestamp = frame.timestamp if frame.timestamp is not None else frame.frame_no / 30.0
+        timestamp_text = f"Time: {timestamp:010.4f}"
+        (text_w, _), _ = cv2.getTextSize(
+            timestamp_text,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            text_thickness,
+        )
+        cv2.putText(
+            output,
+            timestamp_text,
+            (width - text_w - 10, text_y_base + text_spacing * 2),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            text_scale,
+            color,
+            text_thickness,
+            cv2.LINE_AA,
+        )
+
+        if self.motion_handler.motion_mask is not None:
+            scale_x, scale_y = self._contour_scale_cached(frame)
+
+            contours_raw, _ = cv2.findContours(
+                self.motion_handler.motion_mask,
+                cv2.RETR_EXTERNAL,
+                cv2.CHAIN_APPROX_SIMPLE,
+            )
+
+            contours = list(contours_raw)
+            scaled_contours = self._scale_contours(contours, scale_x, scale_y)
+            cv2.drawContours(output, scaled_contours, -1, (0, 0, 255), 2)
+
+        return Frame(
+            raw=output,
+            frame_no=frame.frame_no,
+            motion_proportion=frame.motion_proportion,
+            filter_keep=frame.filter_keep,
+            crop=frame.crop,
+            rescale=frame.rescale,
+            crop_bbox=frame.crop_bbox,
+            tiles=frame.tiles,
+            tiling_cols=frame.tiling_cols,
+            tiling_rows=frame.tiling_rows,
+            tiling_width=frame.tiling_width,
+            tiling_height=frame.tiling_height,
+            timestamp=frame.timestamp,
+        )
+
+
+class DebugVideoWriter(FrameHandler):
+    """Writes debug video frames to a file at full resolution."""
+
+    writer: VideoWriter
+    width: int
+    height: int
+    _closed: bool
+
+    def __init__(self, output_path: Path, width: int, height: int, fps: float) -> None:
+        self.writer = VideoWriter(
+            out_filename=output_path,
+            fps=fps,
+            codec="libx264",
+            crf=23,
+            preset="medium",
+            pix_fmt="yuv420p",
+        )
+        self.width = width
+        self.height = height
+        self._closed = False
+        logger.debug("DebugVideoWriter initialized for %s (%dx%d @ %.2f fps)", output_path, width, height, fps)
+
+    def __enter__(self) -> Self:
+        self.writer.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> Literal[False]:
+        self.close()
+        return False
+
+    def handle(self, frame: Frame) -> Frame:
+        if frame.filter_keep:
+            self.writer.write(frame.raw)
+            logger.debug("Wrote debug frame %d (%dx%d)", frame.frame_no, frame.raw.shape[1], frame.raw.shape[0])
+        else:
+            logger.debug("Skipping debug frame %d (filter_keep=False)", frame.frame_no)
+        return frame
+
+    def close(self) -> None:
+        if not self._closed:
+            self.writer.close()
+            self._closed = True
+            logger.debug("DebugVideoWriter closed")

--- a/src/wildcamtools/lib/frames.py
+++ b/src/wildcamtools/lib/frames.py
@@ -692,7 +692,7 @@ def create_frames(
                 motion_handler=motion_handler,
                 expansion=frame_creation.crop_pan.expansion,
                 inertia=frame_creation.crop_pan.inertia,
-            )
+            ),
         )
 
     if frame_creation.similarity_minimum is not None:
@@ -705,7 +705,7 @@ def create_frames(
                 x=frame_creation.x,
                 y=frame_creation.y,
                 fps=frame_creation.fps,
-            )
+            ),
         )
 
     if frame_creation.tiling is not None:
@@ -714,7 +714,7 @@ def create_frames(
                 cols=frame_creation.tiling.cols,
                 rows=frame_creation.tiling.rows,
                 overlap=frame_creation.tiling.overlap,
-            )
+            ),
         )
 
     handlers.append(FrameImageWriter(frame_creation.tmpdir))
@@ -742,7 +742,7 @@ class FrameImageRecreator:
 
     def __next__(self) -> Frame:
         if self.i >= len(self.raw_images):
-            raise StopIteration()
+            raise StopIteration
 
         raw = cv2.imread(str(self.raw_images[self.i]))
         if raw is None:

--- a/src/wildcamtools/lib/labels.py
+++ b/src/wildcamtools/lib/labels.py
@@ -30,7 +30,11 @@ def save_label(output: Path, video_name: str, label: str) -> None:
     labels[video_name] = label
 
     with tempfile.NamedTemporaryFile(
-        dir=str(output.resolve().parent), prefix=output.stem, delete=False, encoding="utf-8", mode="w"
+        dir=str(output.resolve().parent),
+        prefix=output.stem,
+        delete=False,
+        encoding="utf-8",
+        mode="w",
     ) as f:
         f.write("")
         temp_name = f.name

--- a/src/wildcamtools/lib/perftest.py
+++ b/src/wildcamtools/lib/perftest.py
@@ -6,9 +6,7 @@ from pydantic import BaseModel
 
 
 class PerformanceMetrics(BaseModel):
-    """
-    To store performance metrics of a program execution.
-    """
+    """To store performance metrics of a program execution."""
 
     # Execution wall time in seconds (float)
     time_wall: float

--- a/src/wildcamtools/lib/persistence/filename_datetime.py
+++ b/src/wildcamtools/lib/persistence/filename_datetime.py
@@ -28,6 +28,7 @@ def infer_recorded_at(filename: str, fmt: str | None) -> datetime | None:
     Returns:
         The parsed :class:`datetime`, or ``None`` if ``fmt`` is falsy or the
         basename does not start with a string matching the pattern.
+
     """
     if not fmt:
         return None

--- a/src/wildcamtools/lib/persistence/repository.py
+++ b/src/wildcamtools/lib/persistence/repository.py
@@ -145,6 +145,7 @@ def save_pipeline_run(
 
     Returns:
         The created PipelineRun entity
+
     """
     video_stat = _get_or_create_video_stat(session, outcome.stats)
     _get_or_create_video(session, str(video_path), video_stat, recorded_at=recorded_at)
@@ -314,21 +315,21 @@ def count_animal_status(
 
     present = int(
         session.exec(
-            select(func.count(base.c.video_filename)).select_from(base).where(base.c.is_animal_present.is_(True))
+            select(func.count(base.c.video_filename)).select_from(base).where(base.c.is_animal_present.is_(True)),
         ).scalar()
-        or 0
+        or 0,
     )
     absent = int(
         session.exec(
-            select(func.count(base.c.video_filename)).select_from(base).where(base.c.is_animal_present.is_(False))
+            select(func.count(base.c.video_filename)).select_from(base).where(base.c.is_animal_present.is_(False)),
         ).scalar()
-        or 0
+        or 0,
     )
     unknown = int(
         session.exec(
-            select(func.count(base.c.video_filename)).select_from(base).where(base.c.is_animal_unknown.is_(True))
+            select(func.count(base.c.video_filename)).select_from(base).where(base.c.is_animal_unknown.is_(True)),
         ).scalar()
-        or 0
+        or 0,
     )
     return (present, absent, unknown)
 
@@ -359,7 +360,8 @@ def _filtered_classification_subquery(
     outer query.
     """
     stmt: Any = select(PipelineRun, ClassificationResult).join(
-        ClassificationResult, PipelineRun.final_result_id == ClassificationResult.id
+        ClassificationResult,
+        PipelineRun.final_result_id == ClassificationResult.id,
     )
     if confidences:
         stmt = stmt.where(ClassificationResult.confidence.in_(confidences))  # type: ignore[attr-defined]
@@ -452,14 +454,14 @@ def aggregate_statistics(
     species_rows = session.exec(
         select(base.c.species_name, func.count(base.c.video_filename))
         .group_by(base.c.species_name)
-        .order_by(desc(func.count(base.c.video_filename)))
+        .order_by(desc(func.count(base.c.video_filename))),
     ).all()
     species_counts = {name: int(count) for name, count in species_rows}
 
     confidence_rows = session.exec(
         select(base.c.confidence, func.count(base.c.video_filename))
         .group_by(base.c.confidence)
-        .order_by(desc(func.count(base.c.video_filename)))
+        .order_by(desc(func.count(base.c.video_filename))),
     ).all()
     confidence_counts = {level: int(count) for level, count in confidence_rows}
 

--- a/src/wildcamtools/lib/rtsp.py
+++ b/src/wildcamtools/lib/rtsp.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def socket_check(host: str = "127.0.0.1", port: int = 8554, timeout: float = 1.0) -> bool:
-    """
-    This is a lightweight readiness check for a server being up.
-    """
+    """This is a lightweight readiness check for a server being up."""
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True

--- a/src/wildcamtools/lib/segment.py
+++ b/src/wildcamtools/lib/segment.py
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class VideoSegmenter:
-    """
-    FrameSource that segments video input while emitting frames.
+    """FrameSource that segments video input while emitting frames.
 
     Uses two separate PyAV containers:
     - Container 1: Segment muxer that writes segment files to disk
@@ -30,7 +29,8 @@ class VideoSegmenter:
     This dual-container architecture allows decoding once while muxing
     to both outputs simultaneously.
 
-    Parameters:
+    Parameters
+    ----------
         input_: Path to input video file or RTSP URL
         segment_dir: Directory to write segment files
         segment_duration: Duration of each segment in seconds
@@ -38,6 +38,7 @@ class VideoSegmenter:
 
     TODO: Optimize to use single container with custom output callback
           to avoid maintaining two separate container instances.
+
     """
 
     input_: str | Path
@@ -94,9 +95,13 @@ class VideoSegmenter:
             msg = f"No video streams found in {self.input_}"
             raise ValueError(msg)
         self._video_stream = self._input_container.streams.video[0]
-        self._fps = float(self._video_stream.average_rate or self._video_stream.base_rate or 0.0)
+        self._fps = float(
+            self._video_stream.codec_context.framerate
+            or self._video_stream.average_rate
+            or self._video_stream.base_rate
+            or 0.0
+        )
         if self._fps <= 0:
-            logger.warning("Could not detect FPS from video stream, defaulting to 30.0")
             self._fps = 30.0
         return self
 
@@ -122,12 +127,20 @@ class VideoSegmenter:
 
             # Write metadata sidecar file
             if self._fps is not None:
+                actual_frames = self._frame_no - self._segment_start_frame
+                # Calculate duration from timestamps if available
+                duration = None
+                if self._segment_start_time is not None:
+                    end_time = datetime.now(UTC)
+                    duration = (end_time - self._segment_start_time).total_seconds()
                 metadata = SegmentMetadata(
                     start_frame=self._segment_start_frame,
                     end_frame=self._frame_no,
                     start_time=self._segment_start_time,
-                    end_time=datetime.now(UTC),
+                    end_time=end_time if self._segment_start_time is not None else None,
                     fps=self._fps,
+                    actual_frames=actual_frames,
+                    duration=duration,
                 )
                 metadata_path = SegmentMetadata.get_metadata_path(segment_path)
                 metadata.save(metadata_path)
@@ -234,8 +247,7 @@ class VideoSegmenter:
 
 
 class _PyAVSegmentProcess:
-    """
-    Popen-like wrapper for PyAV-based stream segmenter.
+    """Popen-like wrapper for PyAV-based stream segmenter.
 
     Runs segmentation in a background thread to mimic subprocess behavior.
     Uses stream copy (no re-encoding) for efficiency.
@@ -247,6 +259,7 @@ class _PyAVSegmentProcess:
         returncode: Exit code (0 for success, 1 for error, 2 for no segments, None for running)
         pid: Fake PID (thread identifier)
         restart_on_exit: Whether process should restart on successful completion
+
     """
 
     stdin = None
@@ -366,7 +379,10 @@ class _PyAVSegmentProcess:
 
             if output_container is None:
                 output_container, output_streams = self._create_output_container(
-                    video_stream, audio_stream, segment_index, segment_start_frame
+                    video_stream,
+                    audio_stream,
+                    segment_index,
+                    segment_start_frame,
                 )
 
             self._mux_packet(output_container, packet, output_streams)
@@ -392,7 +408,8 @@ class _PyAVSegmentProcess:
         return packet_time - segment_start_time >= self._duration
 
     def _get_streams(
-        self, input_container: av.container.InputContainer
+        self,
+        input_container: av.container.InputContainer,
     ) -> tuple[av.VideoStream, av.AudioStream | None]:
         """Extract video and audio streams from input container."""
         if not input_container.streams.video:
@@ -402,8 +419,10 @@ class _PyAVSegmentProcess:
         video_stream = input_container.streams.video[0]
         audio_stream = input_container.streams.audio[0] if input_container.streams.audio else None
 
-        # Detect FPS from video stream
-        self._fps = float(video_stream.average_rate or video_stream.base_rate or 0.0)
+        # Detect FPS from video stream (prefer codec framerate for accuracy)
+        self._fps = float(
+            video_stream.codec_context.framerate or video_stream.average_rate or video_stream.base_rate or 0.0
+        )
         if self._fps <= 0:
             logger.warning("Could not detect FPS from video stream, defaulting to 30.0")
             self._fps = 30.0
@@ -472,12 +491,17 @@ class _PyAVSegmentProcess:
 
             # Write metadata sidecar file
             segment_path = Path(container.name)
+            # Calculate actual_frames and duration from timestamps
+            actual_frames = end_frame - start_frame
+            duration = (end_time - start_time) if (start_time is not None and end_time is not None) else None
             metadata = SegmentMetadata(
                 start_frame=start_frame,
                 end_frame=end_frame,
                 start_time=datetime.fromtimestamp(start_time, tz=UTC) if start_time is not None else None,
                 end_time=datetime.fromtimestamp(end_time, tz=UTC) if end_time is not None else None,
                 fps=self._fps or 30.0,
+                actual_frames=actual_frames,
+                duration=duration,
             )
             metadata_path = SegmentMetadata.get_metadata_path(segment_path)
             metadata.save(metadata_path)
@@ -518,13 +542,13 @@ def create_segment_process(
     duration: float,
     restart_on_exit: bool | None = None,
 ) -> _PyAVSegmentProcess:
-    """
-    Create a segmenter process using PyAV (no subprocess).
+    """Create a segmenter process using PyAV (no subprocess).
 
     Uses stream copy (no re-encoding) for efficiency.
     Runs in a background thread to mimic subprocess behavior.
 
-    Parameters:
+    Parameters
+    ----------
         input_: Path to input video file or RTSP URL
         output: Directory to write segment files
         duration: Duration of each segment in seconds
@@ -534,9 +558,11 @@ def create_segment_process(
                         - Stream URLs (rtsp://, http://, etc.) → True
                         - File paths → False
 
-    Returns:
+    Returns
+    -------
         _PyAVSegmentProcess object with poll(), wait(), terminate() methods.
         The object has a `restart_on_exit` attribute indicating the configured behavior.
+
     """
     process = _PyAVSegmentProcess(
         input_=input_,

--- a/src/wildcamtools/lib/segment_metadata.py
+++ b/src/wildcamtools/lib/segment_metadata.py
@@ -16,6 +16,9 @@ class SegmentMetadata(BaseModel):
         start_time: Timestamp of first frame (optional)
         end_time: Timestamp of last frame (optional)
         fps: Frames per second for this segment
+        actual_frames: Actual frame count from ffprobe (optional)
+        duration: Actual duration in seconds (optional)
+
     """
 
     start_frame: int
@@ -23,6 +26,8 @@ class SegmentMetadata(BaseModel):
     start_time: datetime | None = None
     end_time: datetime | None = None
     fps: float
+    actual_frames: int | None = None
+    duration: float | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Convert to dictionary with ISO format timestamps."""
@@ -42,6 +47,7 @@ class SegmentMetadata(BaseModel):
 
         Returns:
             SegmentMetadata object or None if file doesn't exist or is invalid
+
         """
         if not path.exists():
             return None
@@ -64,6 +70,7 @@ class SegmentMetadata(BaseModel):
 
         Args:
             path: Path to write the .meta.json file
+
         """
         with open(path, "w") as f:
             json.dump(self.to_dict(), f, indent=2)
@@ -77,6 +84,7 @@ class SegmentMetadata(BaseModel):
 
         Returns:
             Path to the corresponding .meta.json file
+
         """
         return segment_path.with_suffix(segment_path.suffix + ".meta.json")
 
@@ -89,6 +97,7 @@ class SegmentMetadata(BaseModel):
 
         Returns:
             Path to the corresponding segment video file
+
         """
         if not metadata_path.name.endswith(".meta.json"):
             raise ValueError(f"Invalid metadata path: {metadata_path}")

--- a/src/wildcamtools/lib/states.py
+++ b/src/wildcamtools/lib/states.py
@@ -11,6 +11,7 @@ import numpy as np
 from pydantic import BaseModel
 
 from wildcamtools.lib import Frame, FrameHandler
+from wildcamtools.lib.debug_video import DebugVideoOverlay, DebugVideoWriter
 from wildcamtools.lib.frames import Rescaler
 from wildcamtools.lib.motion import MogMotion
 from wildcamtools.lib.stats import VideoStats, get_video_stats
@@ -85,8 +86,7 @@ class StateTransitionWindowMetrics(BaseModel):
 
 
 class MotionWindow(BaseModel):
-    """
-    Represents a motion detection window with frame and time boundaries.
+    """Represents a motion detection window with frame and time boundaries.
 
     Note: ``start_frame``/``end_frame`` are in **source video indices** (native
     FPS, e.g., 30 fps), not post-filtering indices. When using Rescaler with
@@ -108,6 +108,8 @@ class MotionWindow(BaseModel):
         transition_metrics: State machine transition thresholds used
         transition_window_metrics: Per-state motion statistics during the window
         config: Configuration used for motion detection (for traceability)
+        source_fps: Native FPS of the source video (for offset calculations)
+
     """
 
     start_frame: int
@@ -117,11 +119,11 @@ class MotionWindow(BaseModel):
     transition_metrics: WatcherTransitionMetrics
     transition_window_metrics: dict[WatcherStateEnum, StateTransitionWindowMetrics]
     config: WatchConfig
+    source_fps: float
 
 
 class Watcher(FrameHandler):
-    """
-    ```mermaid
+    """```mermaid
     stateDiagram-v2
         [*] --> preparing %% initializing background history
         preparing --> green %% fully initialized and ready
@@ -300,9 +302,9 @@ def enqueue_motion_windows(  # noqa: C901
     queue: Queue,
     config: WatchConfig,
     hwaccel: str = "",
+    debug_video_path: Path | None = None,
 ) -> None:
-    """
-    Extract motion windows from video stream.
+    """Extract motion windows from video stream.
 
     ``start_frame``/``end_frame`` on the returned ``MotionWindow`` objects use
     source video indices (native FPS), not post-filtering indices. When using
@@ -319,108 +321,9 @@ def enqueue_motion_windows(  # noqa: C901
         queue: Queue to put MotionWindow instances into
         config: WatchConfig with motion detection parameters
         hwaccel: Hardware acceleration method (deployment-specific)
+        debug_video_path: Optional path for debug video output
+
     """
-
-    def _find_motion_times(source: str, stats: VideoStats, watcher: Watcher) -> Generator[MotionWindow]:
-        start_frame: int | None = None
-        start_time: datetime | None = None
-        prev_state: WatcherStateEnum | None = None
-        last_frame_no: int | None = None
-        logger.debug(
-            "Reading %s at %sx%s@%s (%s)",
-            source,
-            stats.x,
-            stats.y,
-            config.motion_detection.fps,
-            config.motion_detection.scale,
-        )
-        rescaler = Rescaler(
-            stats,
-            int(stats.x * config.motion_detection.scale),
-            int(stats.y * config.motion_detection.scale),
-            config.motion_detection.fps,
-        )
-        with VideoReader(source, hwaccel=hwaccel if hwaccel else None) as video_input:
-            for frame in video_input:
-                frame = rescaler.handle(frame)
-                if not frame.filter_keep:
-                    continue
-                # If a new motion window is about to start (GREEN -> AMBER/RED),
-                # reset the watcher's per-window metrics before processing the
-                # entry frame. This scopes the metrics to just the new window
-                # and gives exact min/max/mean/count (no lifetime accumulation
-                # or approximation).
-                if start_frame is None and start_time is None and prev_state == WatcherStateEnum.GREEN:
-                    watcher.transition_window_metrics = {}
-                frame = watcher.handle(frame)
-                last_frame_no = frame.frame_no
-                # Start tracking when transitioning from GREEN to any motion state (AMBER or RED)
-                # This handles both normal transitions (GREEN->AMBER) and zero-duration transitions (GREEN->RED)
-                if start_frame is None and start_time is None:
-                    if watcher.state in (
-                        WatcherStateEnum.AMBER,
-                        WatcherStateEnum.RED,
-                    ):
-                        start_frame = frame.frame_no
-                        start_time = datetime.now(UTC)
-                # End tracking when returning to GREEN from any motion state
-                # Only yield windows that reached RED state (discard GREEN->AMBER->GREEN)
-                elif (
-                    start_frame is not None
-                    and start_time is not None
-                    and watcher.state == WatcherStateEnum.GREEN
-                    and prev_state
-                    in (
-                        WatcherStateEnum.AMBER,
-                        WatcherStateEnum.RED,
-                        WatcherStateEnum.RED_AMBER,
-                    )
-                ):
-                    if not _should_yield_motion_window(watcher):
-                        logger.debug(
-                            "Discarding motion window %d-%d: never reached RED state",
-                            start_frame,
-                            last_frame_no,
-                        )
-                        start_frame = None
-                        start_time = None
-                        continue
-                    end_frame = frame.frame_no
-                    end_time = datetime.now(UTC)
-                    yield MotionWindow(
-                        start_frame=start_frame,
-                        start_time=start_time,
-                        end_frame=end_frame,
-                        end_time=end_time,
-                        transition_metrics=watcher.transition_metrics,
-                        transition_window_metrics=dict(watcher.transition_window_metrics),
-                        config=config,
-                    )
-                    start_frame = None
-                    start_time = None
-
-                prev_state = watcher.state
-
-            # Yield any pending window if video ended during motion
-            # Only yield if the window reached RED state
-            if start_frame is not None and start_time is not None and last_frame_no is not None:
-                if _should_yield_motion_window(watcher):
-                    yield MotionWindow(
-                        start_frame=start_frame,
-                        start_time=start_time,
-                        end_frame=last_frame_no,
-                        end_time=datetime.now(UTC),
-                        transition_metrics=watcher.transition_metrics,
-                        transition_window_metrics=dict(watcher.transition_window_metrics),
-                        config=config,
-                    )
-                else:
-                    logger.debug(
-                        "Discarding pending motion window %d-%d: never reached RED state",
-                        start_frame,
-                        last_frame_no,
-                    )
-
     stats = get_video_stats(rtsp_stream)
     processed_mask = _load_and_resize_mask(
         mask_path=config.motion_mask,
@@ -439,6 +342,136 @@ def enqueue_motion_windows(  # noqa: C901
         ),
         transition_metrics=config.transition_metrics.to_transition_metrics(),
     )
+
+    debug_overlay: DebugVideoOverlay | None = None
+    debug_writer: DebugVideoWriter | None = None
+    if debug_video_path is not None:
+        debug_writer = DebugVideoWriter(
+            output_path=debug_video_path,
+            width=stats.x,
+            height=stats.y,
+            fps=config.motion_detection.fps,
+        )
+        debug_writer.__enter__()
+        debug_overlay = DebugVideoOverlay(
+            watcher=watcher,
+            motion_handler=watcher.motion,
+        )
+        logger.info("Debug video output enabled: %s (full resolution %dx%d)", debug_video_path, stats.x, stats.y)
+
+    def _find_motion_times(  # noqa: C901
+        source: str,
+        stats: VideoStats,
+        watcher: Watcher,
+    ) -> Generator[MotionWindow]:
+        start_frame: int | None = None
+        start_time: datetime | None = None
+        prev_state: WatcherStateEnum | None = None
+        last_frame_no: int | None = None
+        logger.debug(
+            "Reading %s at %sx%s@%s (%s)",
+            source,
+            stats.x,
+            stats.y,
+            config.motion_detection.fps,
+            config.motion_detection.scale,
+        )
+        rescaler = Rescaler(
+            stats,
+            int(stats.x * config.motion_detection.scale),
+            int(stats.y * config.motion_detection.scale),
+            config.motion_detection.fps,
+        )
+        try:
+            with VideoReader(source, hwaccel=hwaccel or None) as video_input:
+                for frame in video_input:
+                    frame = rescaler.handle(frame)
+                    if not frame.filter_keep:
+                        continue
+                    # If a new motion window is about to start (GREEN -> AMBER/RED),
+                    # reset the watcher's per-window metrics before processing the
+                    # entry frame. This scopes the metrics to just the new window
+                    # and gives exact min/max/mean/count (no lifetime accumulation
+                    # or approximation).
+                    if start_frame is None and start_time is None and prev_state == WatcherStateEnum.GREEN:
+                        watcher.transition_window_metrics = {}
+                    frame = watcher.handle(frame)
+                    if debug_writer is not None and debug_overlay is not None:
+                        frame = debug_overlay.handle(frame)
+                        debug_writer.handle(frame)
+                    last_frame_no = frame.frame_no
+                    # Start tracking when transitioning from GREEN to any motion state (AMBER or RED)
+                    # This handles both normal transitions (GREEN->AMBER) and zero-duration transitions (GREEN->RED)
+                    if start_frame is None and start_time is None:
+                        if watcher.state in (
+                            WatcherStateEnum.AMBER,
+                            WatcherStateEnum.RED,
+                        ):
+                            start_frame = frame.frame_no
+                            start_time = datetime.now(UTC)
+                    # End tracking when returning to GREEN from any motion state
+                    # Only yield windows that reached RED state (discard GREEN->AMBER->GREEN)
+                    elif (
+                        start_frame is not None
+                        and start_time is not None
+                        and watcher.state == WatcherStateEnum.GREEN
+                        and prev_state
+                        in (
+                            WatcherStateEnum.AMBER,
+                            WatcherStateEnum.RED,
+                            WatcherStateEnum.RED_AMBER,
+                        )
+                    ):
+                        if not _should_yield_motion_window(watcher):
+                            logger.debug(
+                                "Discarding motion window %d-%d: never reached RED state",
+                                start_frame,
+                                last_frame_no,
+                            )
+                            start_frame = None
+                            start_time = None
+                            continue
+                        end_frame = frame.frame_no
+                        end_time = datetime.now(UTC)
+                        yield MotionWindow(
+                            start_frame=start_frame,
+                            start_time=start_time,
+                            end_frame=end_frame,
+                            end_time=end_time,
+                            transition_metrics=watcher.transition_metrics,
+                            transition_window_metrics=dict(watcher.transition_window_metrics),
+                            config=config,
+                            source_fps=stats.fps,
+                        )
+                        start_frame = None
+                        start_time = None
+
+                    prev_state = watcher.state
+
+                # Yield any pending window if video ended during motion
+                # Only yield if the window reached RED state
+                if start_frame is not None and start_time is not None and last_frame_no is not None:
+                    if _should_yield_motion_window(watcher):
+                        yield MotionWindow(
+                            start_frame=start_frame,
+                            start_time=start_time,
+                            end_frame=last_frame_no,
+                            end_time=datetime.now(UTC),
+                            transition_metrics=watcher.transition_metrics,
+                            transition_window_metrics=dict(watcher.transition_window_metrics),
+                            config=config,
+                            source_fps=stats.fps,
+                        )
+                    else:
+                        logger.debug(
+                            "Discarding pending motion window %d-%d: never reached RED state",
+                            start_frame,
+                            last_frame_no,
+                        )
+        finally:
+            if debug_writer is not None:
+                debug_writer.__exit__(None, None, None)
+
     for motion in _find_motion_times(rtsp_stream, stats, watcher):
         queue.put(motion)
 
@@ -449,6 +482,7 @@ def create_motion_process(
     config: WatchConfig,
     restart_on_exit: bool | None = None,
     hwaccel: str = "",
+    debug_video_path: Path | None = None,
 ) -> MotionProcessWrapper:
     """Spawn a motion-detection process.
 
@@ -464,9 +498,11 @@ def create_motion_process(
         config: WatchConfig with motion detection parameters
         restart_on_exit: Whether to restart the process on exit (auto-detected if None)
         hwaccel: Hardware acceleration method (deployment-specific)
+        debug_video_path: Optional path to write debug video output
 
     Returns:
         MotionProcessWrapper instance
+
     """
     motion_process = Process(
         target=enqueue_motion_windows,
@@ -475,6 +511,7 @@ def create_motion_process(
             "queue": msg_queue,
             "config": config,
             "hwaccel": hwaccel,
+            "debug_video_path": debug_video_path,
         },
         daemon=True,
         name="wildcamtools-motion",

--- a/src/wildcamtools/lib/stats.py
+++ b/src/wildcamtools/lib/stats.py
@@ -27,6 +27,7 @@ class VideoStats(BaseModel):
         shape (tuple[int, int, int]): Shape of the video frames as (height, width, channels)
         nbytes (int): Total bytes required to store one frame
         frame_duration (int): Duration of a single frame in milliseconds
+
     """
 
     # special pydantic configs
@@ -58,8 +59,7 @@ class VideoStats(BaseModel):
 
     @property
     def frame_duration(self) -> int:
-        """
-        Return the duration of a single video frame in milliseconds
+        """Return the duration of a single video frame in milliseconds
 
         Note: this rounds down
         """
@@ -67,14 +67,15 @@ class VideoStats(BaseModel):
 
     @property
     def duration_in_sconds(self) -> float:
-        """
-        Return the total duration of the video in seconds
-        """
+        """Return the total duration of the video in seconds"""
         return self.frame_count / self.fps
 
 
 def get_video_stats(filename: str | Path) -> VideoStats:
     """Retrieves metadata about a video file.
+
+    Uses PyAV for reliable FPS detection, as OpenCV's CAP_PROP_FPS can return
+    incorrect values for certain video codecs.
 
     Args:
         filename (str | Path): Path to the video file
@@ -84,16 +85,40 @@ def get_video_stats(filename: str | Path) -> VideoStats:
 
     Raises:
         RuntimeError: If unable to read frames from the video
+
     """
+    import av
+
+    # Use PyAV for reliable FPS and frame count
+    container = None
     video_capture = None
     try:
+        container = av.open(str(filename))
+        video_stream = container.streams.video[0]
+
+        # Get FPS from codec's base rate (real frame rate)
+        # This is more reliable for frame number calculations than average_rate
+        # which accounts for variable frame rate playback
+        if video_stream.codec_context.framerate:
+            fps = float(video_stream.codec_context.framerate)
+        elif video_stream.average_rate:
+            fps = float(video_stream.average_rate)
+        elif video_stream.guessed_rate:
+            fps = float(video_stream.guessed_rate)
+        else:
+            fps = 30.0  # Fallback
+
+        # Get frame count from stream (prefer frames from codec, then duration-based)
+        if video_stream.frames:
+            frame_count = video_stream.frames
+        elif video_stream.duration is not None and video_stream.time_base:
+            duration_seconds = float(video_stream.duration * video_stream.time_base)
+            frame_count = int(duration_seconds * fps)
+        else:
+            frame_count = 0
+
+        # OpenCV for frame dimensions (more reliable for actual pixel data)
         video_capture = cv2.VideoCapture(str(filename), cv2.CAP_ANY)
-        fps = float(video_capture.get(cv2.CAP_PROP_FPS))
-        frame_count = int(video_capture.get(cv2.CAP_PROP_FRAME_COUNT)) - 1
-        # frame details are more reliable than capture properties
-        # x = cv2.CAP_PROP_FRAME_WIDTH
-        # y = cv2.CAP_PROP_FRAME_HEIGHT
-        # bw = cv2.CAP_PROP_MONOCHROME
         (success, frame) = video_capture.read()
         if not success:
             msg = f"Unable to read frame from {filename}"
@@ -114,3 +139,5 @@ def get_video_stats(filename: str | Path) -> VideoStats:
         if video_capture:
             video_capture.release()
             video_capture = None
+        if container:
+            container.close()

--- a/src/wildcamtools/lib/utils.py
+++ b/src/wildcamtools/lib/utils.py
@@ -24,6 +24,7 @@ def is_stream_url(input_: str | Path) -> bool:
 
     Returns:
         True if input is a stream URL, False if it's a file path
+
     """
     input_str = str(input_)
     return input_str.startswith(("rtsp://", "rtmp://", "http://", "https://"))

--- a/src/wildcamtools/lib/vidio.py
+++ b/src/wildcamtools/lib/vidio.py
@@ -67,8 +67,7 @@ class FileFrameSourceCV2(FrameSource):
             frame = Frame(raw=raw, frame_no=self.frame_no, timestamp=timestamp)
             self.frame_no += 1
             return frame
-        else:
-            raise StopIteration
+        raise StopIteration
 
 
 class VideoReader(FrameSource):
@@ -255,8 +254,7 @@ class VideoReader(FrameSource):
 
 
 class VideoWriter:
-    """
-    Context-managed video writer using PyAV for direct library access.
+    """Context-managed video writer using PyAV for direct library access.
     Accepts numpy arrays (HxWx3 RGB or HxWx4 RGBA) and writes to video files.
     """
 
@@ -298,8 +296,7 @@ class VideoWriter:
         return False
 
     def write(self, frame: np.ndarray) -> None:
-        """
-        Write a single frame to the output video.
+        """Write a single frame to the output video.
         Infers dimensions from the first frame.
         """
         if frame.ndim == 2:

--- a/src/wildcamtools/lib/watch_config.py
+++ b/src/wildcamtools/lib/watch_config.py
@@ -19,6 +19,7 @@ class MotionDetectionConfig(BaseModel):
         scale: Frame scale factor (< 1.0)
         fps: Target frames per second (>= 1.0)
         segment_duration: Segment duration in seconds
+
     """
 
     history: Annotated[float, Field(strict=True, ge=0.0, description="MOG2 history in seconds")] = 10.0
@@ -47,6 +48,7 @@ class WatcherTransitionMetricsConfig(BaseModel):
         red_to_red_amber_proportion_max: Maximum motion proportion to transition RED -> RED_AMBER
         red_amber_to_red_proportion_min: Minimum motion proportion to transition RED_AMBER -> RED
         red_amber_to_green_duration: Duration in RED_AMBER state before transitioning to GREEN
+
     """
 
     preparing_duration: Annotated[float, Field(strict=True, ge=0.0)] = 10.0
@@ -114,6 +116,7 @@ class WatchConfig(BaseModel):
             }
         }
         ```
+
     """
 
     model_config = ConfigDict(
@@ -140,8 +143,8 @@ class WatchConfig(BaseModel):
                     "red_amber_to_red_proportion_min": 0.01,
                     "red_amber_to_green_duration": 5.0,
                 },
-            }
-        }
+            },
+        },
     )
 
     rtsp_stream: Annotated[str, Field(min_length=1, description="RTSP URL or file path to process")]
@@ -164,6 +167,7 @@ class WatchConfig(BaseModel):
 
         Raises:
             ValueError: If an environment variable is not set.
+
         """
 
         def replacer(match: re.Match[str]) -> str:
@@ -207,6 +211,7 @@ class WatchConfig(BaseModel):
         Raises:
             FileNotFoundError: If the config file does not exist.
             pydantic.ValidationError: If the config file contains invalid data.
+
         """
         content = path.read_text()
         return cls.model_validate_json(content)
@@ -217,6 +222,7 @@ class WatchConfig(BaseModel):
         Args:
             path: Path to the JSON configuration file.
             indent: JSON indentation level.
+
         """
         json_str = self.model_dump_json(indent=indent)
         path.write_text(json_str)
@@ -229,5 +235,6 @@ class WatchConfig(BaseModel):
 
         Returns:
             Frame count for MOG2 history (minimum 1).
+
         """
         return max(1, round(self.motion_detection.history * self.motion_detection.fps))

--- a/src/wildcamtools/web/db.py
+++ b/src/wildcamtools/web/db.py
@@ -87,7 +87,7 @@ def _display_config_summary(config: dict[str, Any]) -> None:
         if "frame_extractor" in config:
             fe = config["frame_extractor"]
             st.json({
-                "frame_extractor": {"extractor_type": fe.get("extractor_type"), "resolution": fe.get("resolution")}
+                "frame_extractor": {"extractor_type": fe.get("extractor_type"), "resolution": fe.get("resolution")},
             })
     with col2:
         if "llm" in config:
@@ -311,8 +311,7 @@ def _render_browse_filters(
 
 def _render_browse_pagination(total: int) -> int:
     max_page = max(0, (total - 1) // PAGE_SIZE) if total > 0 else 0
-    if st.session_state.browse_page > max_page:
-        st.session_state.browse_page = max_page
+    st.session_state.browse_page = min(st.session_state.browse_page, max_page)
     page = st.session_state.browse_page
 
     nav_l, nav_m, nav_r = st.columns([1, 2, 1])

--- a/src/wildcamtools/web/label.py
+++ b/src/wildcamtools/web/label.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 def handle_navigation(videos: list[str]) -> None:
     """Handle previous and skip buttons."""
-
     col1, col2 = st.columns(2)
     with col1:
         if st.button("Previous") and st.session_state.vid_idx > 0:
@@ -31,7 +30,6 @@ def handle_navigation(videos: list[str]) -> None:
 
 def save_and_next(output_path: Path, current_vid_name: str, label: str, videos: list[str]) -> None:
     """Save label and advance to next video."""
-
     if label:
         save_label(output_path, current_vid_name, label)
         st.session_state.labels[current_vid_name] = label

--- a/tests/cli/test_ai.py
+++ b/tests/cli/test_ai.py
@@ -100,7 +100,10 @@ class TestRunCommand:
         assert result.exit_code != 0
 
     def test_run_success_with_mocked_pipeline(
-        self, sample_config_file: Path, sample_video_file: Path, tmp_path: Path
+        self,
+        sample_config_file: Path,
+        sample_video_file: Path,
+        tmp_path: Path,
     ) -> None:
         from wildcamtools.lib.ai import AiPipelineConfig, PipelineOutcome
         from wildcamtools.lib.ai.types import ConfidenceLevel, RichResult
@@ -170,7 +173,10 @@ class TestRunCommand:
 
 class TestRunCommandIntegration:
     def test_run_config_with_env_var(
-        self, tmp_path: Path, sample_video_file: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        sample_video_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("TEST_API_KEY", "secret-key")
 
@@ -215,7 +221,10 @@ class TestRunCommandIntegration:
 
     @pytest.mark.parametrize("resolution", [[640, 360], [1280, 720], [320, 240]])
     def test_run_with_different_resolutions(
-        self, resolution: list[int], tmp_path: Path, sample_video_file: Path
+        self,
+        resolution: list[int],
+        tmp_path: Path,
+        sample_video_file: Path,
     ) -> None:
         config = {
             "frame_extractor": {
@@ -298,29 +307,34 @@ class TestRunEvaluateCommand:
         ]
         labels_file = tmp_path / "labels.jsonl"
         with open(labels_file, "w") as f:
-            for label in labels:
-                f.write(json.dumps(label) + "\n")
+            f.writelines(json.dumps(label) + "\n" for label in labels)
         return labels_file
 
     def test_run_evaluate_missing_config(self, sample_comparison_config_file: Path, sample_labels_file: Path) -> None:
         result = runner.invoke(
-            ai_app, ["run-evaluate", "nonexistent.json", str(sample_comparison_config_file), str(sample_labels_file)]
+            ai_app,
+            ["run-evaluate", "nonexistent.json", str(sample_comparison_config_file), str(sample_labels_file)],
         )
         assert result.exit_code == 1
         assert "Error: Config file not found" in result.stderr or "Error: Config file not found" in result.stdout
 
     def test_run_evaluate_missing_labels(self, sample_config_file: Path, sample_comparison_config_file: Path) -> None:
         result = runner.invoke(
-            ai_app, ["run-evaluate", str(sample_config_file), str(sample_comparison_config_file), "nonexistent.jsonl"]
+            ai_app,
+            ["run-evaluate", str(sample_config_file), str(sample_comparison_config_file), "nonexistent.jsonl"],
         )
         assert result.exit_code == 1
         assert "Error: Labels file not found" in result.stderr or "Error: Labels file not found" in result.stdout
 
     def test_run_evaluate_config_not_file(
-        self, tmp_path: Path, sample_comparison_config_file: Path, sample_labels_file: Path
+        self,
+        tmp_path: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
     ) -> None:
         result = runner.invoke(
-            ai_app, ["run-evaluate", str(tmp_path), str(sample_comparison_config_file), str(sample_labels_file)]
+            ai_app,
+            ["run-evaluate", str(tmp_path), str(sample_comparison_config_file), str(sample_labels_file)],
         )
         assert result.exit_code == 1
         assert (
@@ -328,10 +342,14 @@ class TestRunEvaluateCommand:
         )
 
     def test_run_evaluate_labels_not_file(
-        self, tmp_path: Path, sample_config_file: Path, sample_comparison_config_file: Path
+        self,
+        tmp_path: Path,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
     ) -> None:
         result = runner.invoke(
-            ai_app, ["run-evaluate", str(sample_config_file), str(sample_comparison_config_file), str(tmp_path)]
+            ai_app,
+            ["run-evaluate", str(sample_config_file), str(sample_comparison_config_file), str(tmp_path)],
         )
         assert result.exit_code == 1
         assert (
@@ -339,7 +357,10 @@ class TestRunEvaluateCommand:
         )
 
     def test_run_evaluate_video_dir_not_found(
-        self, sample_config_file: Path, sample_comparison_config_file: Path, sample_labels_file: Path
+        self,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
     ) -> None:
         result = runner.invoke(
             ai_app,
@@ -358,7 +379,10 @@ class TestRunEvaluateCommand:
         )
 
     def test_run_evaluate_video_dir_not_directory(
-        self, sample_config_file: Path, sample_comparison_config_file: Path, sample_labels_file: Path
+        self,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
     ) -> None:
         result = runner.invoke(
             ai_app,
@@ -378,7 +402,10 @@ class TestRunEvaluateCommand:
         )
 
     def test_run_evaluate_invalid_max_workers(
-        self, sample_config_file: Path, sample_comparison_config_file: Path, sample_labels_file: Path
+        self,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
     ) -> None:
         result = runner.invoke(
             ai_app,

--- a/tests/cli/test_watch_output_naming.py
+++ b/tests/cli/test_watch_output_naming.py
@@ -25,6 +25,7 @@ def sample_motion_window(sample_watch_config: WatchConfig) -> MotionWindow:
         transition_metrics=WatcherTransitionMetrics(),
         transition_window_metrics={},
         config=sample_watch_config,
+        source_fps=30.0,
     )
 
 
@@ -38,6 +39,7 @@ def test_output_clip_metadata_model(sample_watch_config: WatchConfig) -> None:
         transition_metrics=WatcherTransitionMetrics(),
         transition_window_metrics={},
         config=sample_watch_config,
+        source_fps=30.0,
     )
 
     # Test with timestamps (stream)
@@ -129,6 +131,7 @@ def test_output_clip_naming_uses_motion_window_frames(tmp_path: Path, sample_wat
         transition_metrics=WatcherTransitionMetrics(),
         transition_window_metrics={},
         config=sample_watch_config,
+        source_fps=30.0,
     )
 
     # Simulate offset calculation (10 seconds at 30 FPS = 300 frames)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def fixture_video_frame_generator(video_path: Path) -> Generator[Callable[[], Ge
         with VideoReader(video_path) as video_source:
             yield from video_source
 
-    yield internal_generator
+    return internal_generator
 
 
 @pytest.fixture(name="rtsp_server", scope="session")

--- a/tests/lib/ai/llm/test_llamacpp.py
+++ b/tests/lib/ai/llm/test_llamacpp.py
@@ -37,7 +37,9 @@ class TestLlamaCppLlmSystemMessage:
 
     @patch("wildcamtools.lib.ai.llm.llamacpp.openai_lib.OpenAI")
     def test_message_with_schema_includes_system_message(
-        self, mock_client_class: MagicMock, sample_image: Path
+        self,
+        mock_client_class: MagicMock,
+        sample_image: Path,
     ) -> None:
         mock_client = MagicMock()
         mock_response = MagicMock()
@@ -164,7 +166,10 @@ class TestLlamaCppLlmSystemMessage:
     @pytest.mark.parametrize("image_count", [0, 1, 3, 5])
     @patch("wildcamtools.lib.ai.llm.llamacpp.openai_lib.OpenAI")
     def test_message_with_schema_various_image_counts(
-        self, mock_client_class: MagicMock, tmp_path: Path, image_count: int
+        self,
+        mock_client_class: MagicMock,
+        tmp_path: Path,
+        image_count: int,
     ) -> None:
         mock_client = MagicMock()
         mock_response = MagicMock()
@@ -201,7 +206,10 @@ class TestLlamaCppLlmSystemMessage:
 
     @patch("wildcamtools.lib.ai.llm.llamacpp.openai_lib.OpenAI")
     def test_system_message_logged_at_debug_level(
-        self, mock_client_class: MagicMock, sample_image: Path, caplog: pytest.LogCaptureFixture
+        self,
+        mock_client_class: MagicMock,
+        sample_image: Path,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
 
         mock_client = MagicMock()

--- a/tests/lib/ai/llm/test_ollama.py
+++ b/tests/lib/ai/llm/test_ollama.py
@@ -33,7 +33,9 @@ class TestOllamaLlmSystemMessage:
 
     @patch("wildcamtools.lib.ai.llm.ollama.ollama_lib.Client")
     def test_message_with_schema_includes_system_message(
-        self, mock_client_class: MagicMock, sample_image: Path
+        self,
+        mock_client_class: MagicMock,
+        sample_image: Path,
     ) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
@@ -148,7 +150,10 @@ class TestOllamaLlmSystemMessage:
     @pytest.mark.parametrize("image_count", [0, 1, 3, 5])
     @patch("wildcamtools.lib.ai.llm.ollama.ollama_lib.Client")
     def test_message_with_schema_various_image_counts(
-        self, mock_client_class: MagicMock, tmp_path: Path, image_count: int
+        self,
+        mock_client_class: MagicMock,
+        tmp_path: Path,
+        image_count: int,
     ) -> None:
         mock_client = MagicMock()
         mock_client.chat.return_value = MagicMock()
@@ -183,7 +188,10 @@ class TestOllamaLlmSystemMessage:
 
     @patch("wildcamtools.lib.ai.llm.ollama.ollama_lib.Client")
     def test_system_message_logged_at_debug_level(
-        self, mock_client_class: MagicMock, sample_image: Path, caplog: pytest.LogCaptureFixture
+        self,
+        mock_client_class: MagicMock,
+        sample_image: Path,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
 
         mock_client = MagicMock()

--- a/tests/lib/ai/test_batch_processing.py
+++ b/tests/lib/ai/test_batch_processing.py
@@ -167,7 +167,7 @@ class TestRunBatchCommand:
                     llm=LlmConfig(backend=Backend.OLLAMA, model="test"),
                 ),
                 reconciler=ReconcilerConfig(),
-            ).model_dump_json()
+            ).model_dump_json(),
         )
         video_dir = tmp_path / "videos"
         output_dir = tmp_path / "results"
@@ -194,7 +194,7 @@ class TestRunBatchCommand:
                     llm=LlmConfig(backend=Backend.OLLAMA, model="test"),
                 ),
                 reconciler=ReconcilerConfig(),
-            ).model_dump_json()
+            ).model_dump_json(),
         )
         video_dir = tmp_path / "videos"
         video_dir.mkdir()
@@ -222,7 +222,7 @@ class TestRunBatchCommand:
                     llm=LlmConfig(backend=Backend.OLLAMA, model="test"),
                 ),
                 reconciler=ReconcilerConfig(),
-            ).model_dump_json()
+            ).model_dump_json(),
         )
         video_dir = tmp_path / "videos"
         video_dir.mkdir()
@@ -250,7 +250,7 @@ class TestRunBatchCommand:
                     llm=LlmConfig(backend=Backend.OLLAMA, model="test"),
                 ),
                 reconciler=ReconcilerConfig(),
-            ).model_dump_json()
+            ).model_dump_json(),
         )
         video_dir = tmp_path / "videos"
         video_dir.mkdir()
@@ -286,7 +286,7 @@ class TestRunBatchCommand:
                     llm=LlmConfig(backend=Backend.OLLAMA, model="test"),
                 ),
                 reconciler=ReconcilerConfig(),
-            ).model_dump_json()
+            ).model_dump_json(),
         )
         video_dir = tmp_path / "videos"
         video_dir.mkdir()
@@ -452,7 +452,7 @@ class TestRunPipelineWorkerDispatch:
                         confidence=ConfidenceLevel.HIGH,
                     ),
                     description=BatchDescription(description="A badger forages."),
-                )
+                ),
             ],
         )
         mock_pipeline = MagicMock()

--- a/tests/lib/ai/test_description_pipeline.py
+++ b/tests/lib/ai/test_description_pipeline.py
@@ -111,14 +111,14 @@ class TestDescriptionImageBatchQuery:
         mock_llm = MockDescriptionLlm(next_description="desc 1")
         query = DescriptionImageBatchQuery(llm=mock_llm)
         batch_a = ExtractedBatch(
-            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)]
+            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)],
         )
         batch_b = ExtractedBatch(
-            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)]
+            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)],
         )
 
         enriched: ExtractedFramesWithResults[BatchDescription] = query.query_image_batches(
-            ExtractedFrames(batches=[batch_a, batch_b])
+            ExtractedFrames(batches=[batch_a, batch_b]),
         )
         assert len(enriched.batches) == 2
         assert all(b.result is not None for b in enriched.batches)

--- a/tests/lib/ai/test_pipeline.py
+++ b/tests/lib/ai/test_pipeline.py
@@ -199,16 +199,15 @@ class MockVerifiedLlm(AbstractLlm):
                 verified=self.verification_verified,
             )
             return result
-        else:
-            self.last_prompt = message
-            result = RichResult(
-                is_animal_present=self.initial_species not in ("unknown", "no animal"),
-                is_animal_unknown=self.initial_species == "unknown",
-                defining_features="test features",
-                species_name=self.initial_species,
-                confidence=ConfidenceLevel.HIGH,
-            )
-            return result
+        self.last_prompt = message
+        result = RichResult(
+            is_animal_present=self.initial_species not in ("unknown", "no animal"),
+            is_animal_unknown=self.initial_species == "unknown",
+            defining_features="test features",
+            species_name=self.initial_species,
+            confidence=ConfidenceLevel.HIGH,
+        )
+        return result
 
 
 class TestFpsRescalingFrameSelector:
@@ -644,7 +643,7 @@ class TestExtractedFrames:
         """Test frame_ids with multiple batches."""
         batch1 = ExtractedBatch(selected_frames=[ExtractedFrame(path=Path(f"f{i}.jpg"), frame_no=i) for i in range(3)])
         batch2 = ExtractedBatch(
-            selected_frames=[ExtractedFrame(path=Path(f"f{i}.jpg"), frame_no=i + 10) for i in range(2)]
+            selected_frames=[ExtractedFrame(path=Path(f"f{i}.jpg"), frame_no=i + 10) for i in range(2)],
         )
         frames = ExtractedFrames(batches=[batch1, batch2])
         assert frames.frame_ids == [[0, 1, 2], [10, 11]]
@@ -818,10 +817,12 @@ class TestPipelineOutcome:
         )
         stats = VideoStats(fps=30.0, frame_count=100, x=1920, y=1080, colourspace=Colourspace.RGB)
         batch1 = RichResultBatchResult(
-            selected_frames=[ExtractedFrame(path=Path("f1.jpg"), frame_no=1)], result=result1
+            selected_frames=[ExtractedFrame(path=Path("f1.jpg"), frame_no=1)],
+            result=result1,
         )
         batch2 = RichResultBatchResult(
-            selected_frames=[ExtractedFrame(path=Path("f2.jpg"), frame_no=2)], result=result2
+            selected_frames=[ExtractedFrame(path=Path("f2.jpg"), frame_no=2)],
+            result=result2,
         )
         original = RichResultPipelineOutcome(result=result1, stats=stats, batches=[batch1, batch2])
 
@@ -1158,11 +1159,11 @@ class TestAICroppedFrameImageExtractor:
                                 right=0.8,
                                 top=0.2,
                                 bottom=0.8,
-                            )
+                            ),
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.25)
         extractor = AICroppedFrameImageExtractor(aicropfinder=aicropfinder)
@@ -1190,11 +1191,11 @@ class TestAICroppedFrameImageExtractor:
                                 right=0.8,
                                 top=0.2,
                                 bottom=0.8,
-                            )
+                            ),
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         extractor = AICroppedFrameImageExtractor(aicropfinder=aicropfinder, resolution=(320, 240))
@@ -1226,9 +1227,9 @@ class TestAICroppedFrameImageExtractor:
                             )
                             for i in range(len(sample_frames))
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         resolution = (320, 240)
@@ -1263,9 +1264,9 @@ class TestAICroppedFrameImageExtractor:
                             )
                             for i in range(10)
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         extractor = AICroppedFrameImageExtractor(aicropfinder=aicropfinder)
@@ -1296,9 +1297,9 @@ class TestAICroppedFrameImageExtractor:
                             )
                             for i in range(len(sample_frames))
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         extractor = AICroppedFrameImageExtractor(aicropfinder=aicropfinder)
@@ -1330,9 +1331,9 @@ class TestAICroppedFrameImageExtractor:
                             )
                             for i in range(75)
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         frames = []
@@ -1371,9 +1372,9 @@ class TestAICroppedFrameImageExtractor:
                             )
                             for i in range(len(sample_frames))
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         resolution = (320, 240)
@@ -1420,9 +1421,9 @@ class TestAICroppedFrameImageExtractor:
                             )
                             for i in range(len(sample_frames))
                         ],
-                    )
-                ]
-            )
+                    ),
+                ],
+            ),
         )
         aicropfinder = AICropFinder(analyser=mock_llm, expansion=0.0)
         extractor = AICroppedFrameImageExtractor(aicropfinder=aicropfinder)
@@ -1717,10 +1718,10 @@ class TestLlmImageBatchQuery:
             prompt="Test prompt",
         )
         batch1 = ExtractedBatch(
-            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)]
+            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)],
         )
         batch2 = ExtractedBatch(
-            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)]
+            selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)],
         )
         extracted_frames = ExtractedFrames(batches=[batch1, batch2])
         enriched_frames = query.query_image_batches(extracted_frames)
@@ -1742,7 +1743,7 @@ class TestLlmImageBatchQuery:
         batches = []
         for _ in range(3):
             batch = ExtractedBatch(
-                selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)]
+                selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)],
             )
             batches.append(batch)
         extracted_frames = ExtractedFrames(batches=batches)
@@ -1765,7 +1766,7 @@ class TestLlmImageBatchQuery:
         batches = []
         for _ in range(batch_count):
             batch = ExtractedBatch(
-                selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)]
+                selected_frames=[ExtractedFrame(path=p, frame_no=i) for i, p in enumerate(sample_image_paths)],
             )
             batches.append(batch)
         extracted_frames = ExtractedFrames(batches=batches)

--- a/tests/lib/ai/test_pipeline_evaluation.py
+++ b/tests/lib/ai/test_pipeline_evaluation.py
@@ -415,7 +415,7 @@ class TestPipelineEvaluationSummary:
                         confidence=ConfidenceLevel.HIGH,
                     ),
                     label="otter",
-                )
+                ),
             )
         for i in range(incorrect):
             results.append(
@@ -430,7 +430,7 @@ class TestPipelineEvaluationSummary:
                         confidence=ConfidenceLevel.HIGH,
                     ),
                     label="otter",
-                )
+                ),
             )
         summary = PipelineEvaluationSummary(
             results=results,
@@ -853,12 +853,14 @@ class TestEvaluateAiPipeline:
         ]
         labels_file = tmp_path / "labels.jsonl"
         with open(labels_file, "w") as f:
-            for label in labels:
-                f.write(json.dumps(label) + "\n")
+            f.writelines(json.dumps(label) + "\n" for label in labels)
         return labels_file
 
     def test_missing_config_file(
-        self, tmp_path: Path, sample_comparison_config_file: Path, sample_labels_file: Path
+        self,
+        tmp_path: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
     ) -> None:
         with pytest.raises(FileNotFoundError, match="Config file not found"):
             evaluate_ai_pipeline(
@@ -868,7 +870,10 @@ class TestEvaluateAiPipeline:
             )
 
     def test_config_not_file(
-        self, tmp_path: Path, sample_comparison_config_file: Path, sample_labels_file: Path
+        self,
+        tmp_path: Path,
+        sample_comparison_config_file: Path,
+        sample_labels_file: Path,
     ) -> None:
         with pytest.raises(ValueError, match="Config path is not a file"):
             evaluate_ai_pipeline(
@@ -878,7 +883,10 @@ class TestEvaluateAiPipeline:
             )
 
     def test_missing_labels_file(
-        self, tmp_path: Path, sample_config_file: Path, sample_comparison_config_file: Path
+        self,
+        tmp_path: Path,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
     ) -> None:
         with pytest.raises(FileNotFoundError, match="Labels file not found"):
             evaluate_ai_pipeline(
@@ -888,7 +896,10 @@ class TestEvaluateAiPipeline:
             )
 
     def test_labels_not_file(
-        self, tmp_path: Path, sample_config_file: Path, sample_comparison_config_file: Path
+        self,
+        tmp_path: Path,
+        sample_config_file: Path,
+        sample_comparison_config_file: Path,
     ) -> None:
         with pytest.raises(ValueError, match="Labels path is not a file"):
             evaluate_ai_pipeline(
@@ -1087,14 +1098,14 @@ class TestIntegration:
                 "reconciler": {
                     "reconciler_type": "majority",
                 },
-            })
+            }),
         )
 
         comparison_config_file = tmp_path / "comparison_config.json"
         comparison_config_file.write_text(
             json.dumps({
                 "comparator_type": "exact",
-            })
+            }),
         )
 
         labels_file = tmp_path / "labels.jsonl"
@@ -1103,8 +1114,7 @@ class TestIntegration:
             {"video": "short.mp4", "label": "cat"},
         ]
         with open(labels_file, "w") as f:
-            for label in labels:
-                f.write(json.dumps(label) + "\n")
+            f.writelines(json.dumps(label) + "\n" for label in labels)
 
         with (
             patch.object(AiPipelineConfig, "model_validate") as mock_validate,
@@ -1203,14 +1213,14 @@ class TestIntegration:
                 "reconciler": {
                     "reconciler_type": "majority",
                 },
-            })
+            }),
         )
 
         comparison_config_file = tmp_path / "comparison_config.json"
         comparison_config_file.write_text(
             json.dumps({
                 "comparator_type": "exact",
-            })
+            }),
         )
 
         labels_file = tmp_path / "labels.jsonl"
@@ -1218,8 +1228,7 @@ class TestIntegration:
             {"video": "test.mp4", "label": "otter"},
         ]
         with open(labels_file, "w") as f:
-            for label in labels:
-                f.write(json.dumps(label) + "\n")
+            f.writelines(json.dumps(label) + "\n" for label in labels)
 
         with (
             patch.object(AiPipelineConfig, "model_validate") as mock_validate,

--- a/tests/lib/test_debug_video.py
+++ b/tests/lib/test_debug_video.py
@@ -1,0 +1,400 @@
+"""Tests for debug video output functionality."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import cv2
+import numpy as np
+
+from wildcamtools.lib import Frame
+from wildcamtools.lib.debug_video import DebugVideoOverlay, DebugVideoWriter
+from wildcamtools.lib.motion import MogMotion
+from wildcamtools.lib.states import Watcher, WatcherStateEnum
+
+
+class TestDebugVideoOverlay:
+    """Tests for DebugVideoOverlay handler."""
+
+    def test_overlay_initializes_with_watcher(self) -> None:
+        """Test that DebugVideoOverlay initializes correctly with watcher."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.GREEN
+        mock_motion = Mock(spec=MogMotion)
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        assert overlay.watcher is mock_watcher
+        assert overlay.motion_handler is mock_motion
+        assert WatcherStateEnum.GREEN in overlay.state_colors
+
+    def test_overlay_draws_border_on_frame(self) -> None:
+        """Test that overlay draws colored border on frame."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.RED
+        mock_motion = Mock(spec=MogMotion)
+        mock_motion.motion_mask = None
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((100, 100, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+        frame.rescale = np.zeros((50, 50, 3), dtype=np.uint8)
+
+        result = overlay.handle(frame)
+
+        assert result.raw is not None
+        assert result.raw.shape == (100, 100, 3)
+
+    def test_overlay_state_colors(self) -> None:
+        """Test that all watcher states have defined colors."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.GREEN
+        mock_motion = Mock(spec=MogMotion)
+        mock_motion.motion_mask = None
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        expected_states = [
+            WatcherStateEnum.PREPARING,
+            WatcherStateEnum.GREEN,
+            WatcherStateEnum.AMBER,
+            WatcherStateEnum.RED,
+            WatcherStateEnum.RED_AMBER,
+            WatcherStateEnum.DISABLED,
+        ]
+
+        for state in expected_states:
+            assert state.value in overlay.state_colors or state in overlay.state_colors
+
+    def test_overlay_draws_on_full_resolution(self) -> None:
+        """Test that overlay draws on full-resolution frame (raw), not scaled."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.GREEN
+        mock_motion = Mock(spec=MogMotion)
+        mock_motion.motion_mask = None
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        original_frame = Frame(
+            raw=np.zeros((1920, 1080, 3), dtype=np.uint8),
+            frame_no=42,
+            motion_proportion=0.1234,
+            filter_keep=True,
+            timestamp=5.6789,
+        )
+        original_frame.rescale = np.zeros((160, 120, 3), dtype=np.uint8)
+
+        result = overlay.handle(original_frame)
+
+        assert result.raw.shape == (1920, 1080, 3)
+        assert result.rescale.shape == (160, 120, 3)
+        assert result.frame_no == original_frame.frame_no
+        assert result.motion_proportion == original_frame.motion_proportion
+        assert result.filter_keep == original_frame.filter_keep
+        assert result.timestamp == original_frame.timestamp
+
+    def test_overlay_draws_contours_when_mask_present(self) -> None:
+        """Test that overlay draws contours when motion mask is available."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.RED
+        mock_motion = Mock(spec=MogMotion)
+
+        mask = np.zeros((50, 50), dtype=np.uint8)
+        cv2.rectangle(mask, (10, 10), (20, 20), 255, -1)
+        mock_motion.motion_mask = mask
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((100, 100, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+        frame.rescale = np.zeros((50, 50, 3), dtype=np.uint8)
+
+        result = overlay.handle(frame)
+
+        assert result.raw is not None
+        assert result.raw.shape == (100, 100, 3)
+
+    def test_overlay_scales_contours_to_full_resolution(self) -> None:
+        """Test that contours are scaled from motion resolution to full resolution."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.RED
+        mock_motion = Mock(spec=MogMotion)
+
+        mask = np.zeros((50, 50), dtype=np.uint8)
+        cv2.rectangle(mask, (10, 10), (20, 20), 255, -1)
+        mock_motion.motion_mask = mask
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((200, 200, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+
+        result = overlay.handle(frame)
+
+        assert result.raw is not None
+        assert result.raw.shape == (200, 200, 3)
+        assert overlay._contour_scale == (4.0, 4.0)
+
+    def test_overlay_default_scale_when_mask_none(self) -> None:
+        """Test that contour scale defaults to (1.0, 1.0) when mask is None."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.GREEN
+        mock_motion = Mock(spec=MogMotion)
+        mock_motion.motion_mask = None
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((1920, 1080, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+
+        scale = overlay._contour_scale_cached(frame)
+
+        assert scale == (1.0, 1.0)
+
+    def test_overlay_extreme_scale_factors(self) -> None:
+        """Test contour scaling with extreme scale factors."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.RED
+        mock_motion = Mock(spec=MogMotion)
+
+        mask = np.zeros((10, 10), dtype=np.uint8)
+        cv2.rectangle(mask, (2, 2), (5, 5), 255, -1)
+        mock_motion.motion_mask = mask
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((1000, 1000, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+
+        result = overlay.handle(frame)
+
+        assert result.raw is not None
+        assert result.raw.shape == (1000, 1000, 3)
+        assert overlay._contour_scale == (100.0, 100.0)
+
+    def test_overlay_non_uniform_scale(self) -> None:
+        """Test contour scaling with non-uniform aspect ratio."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.RED
+        mock_motion = Mock(spec=MogMotion)
+
+        mask = np.zeros((50, 100), dtype=np.uint8)
+        cv2.rectangle(mask, (10, 10), (20, 20), 255, -1)
+        mock_motion.motion_mask = mask
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((1080, 1920, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+
+        result = overlay.handle(frame)
+
+        assert result.raw is not None
+        assert result.raw.shape == (1080, 1920, 3)
+        assert overlay._contour_scale == (19.2, 21.6)
+
+    def test_overlay_handles_missing_rescale(self) -> None:
+        """Test that overlay handles frames without rescale attribute."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.GREEN
+        mock_motion = Mock(spec=MogMotion)
+        mock_motion.motion_mask = None
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        frame = Frame(
+            raw=np.zeros((100, 100, 3), dtype=np.uint8),
+            frame_no=1,
+            motion_proportion=0.5,
+            timestamp=1.0,
+        )
+
+        result = overlay.handle(frame)
+
+        assert result.raw is not None
+        assert result.raw.shape == (100, 100, 3)
+
+
+class TestDebugVideoWriter:
+    """Tests for DebugVideoWriter handler."""
+
+    def test_writer_context_manager(self, tmp_path: Path) -> None:
+        """Test that DebugVideoWriter works as context manager."""
+        output_path = tmp_path / "debug.mp4"
+
+        with DebugVideoWriter(output_path, width=100, height=100, fps=30.0) as writer:
+            assert writer._closed is False
+
+        assert writer._closed is True
+
+    def test_writer_close_is_idempotent(self, tmp_path: Path) -> None:
+        """Test that calling close() multiple times is safe."""
+        output_path = tmp_path / "debug.mp4"
+
+        writer = DebugVideoWriter(output_path, width=100, height=100, fps=30.0)
+        writer.__enter__()
+
+        writer.close()
+        writer.close()
+
+        assert writer._closed is True
+
+    def test_writer_skips_filtered_frames(self, tmp_path: Path) -> None:
+        """Test that writer skips frames with filter_keep=False."""
+        output_path = tmp_path / "debug.mp4"
+
+        with DebugVideoWriter(output_path, width=100, height=100, fps=30.0) as writer:
+            frame = Frame(
+                raw=np.zeros((100, 100, 3), dtype=np.uint8),
+                frame_no=1,
+                filter_keep=False,
+            )
+            frame.rescale = np.zeros((100, 100, 3), dtype=np.uint8)
+
+            result = writer.handle(frame)
+
+            assert result is frame
+
+    def test_writer_writes_raw_frame(self, tmp_path: Path) -> None:
+        """Test that writer writes raw (full-resolution) frames."""
+        output_path = tmp_path / "debug.mp4"
+
+        with DebugVideoWriter(output_path, width=1920, height=1080, fps=30.0) as writer:
+            frame = Frame(
+                raw=np.zeros((1920, 1080, 3), dtype=np.uint8),
+                frame_no=1,
+                filter_keep=True,
+            )
+            frame.rescale = np.zeros((160, 120, 3), dtype=np.uint8)
+
+            result = writer.handle(frame)
+
+            assert result is frame
+
+        assert output_path.exists()
+
+    def test_writer_writes_valid_frames(self, tmp_path: Path) -> None:
+        """Test that writer writes raw frames."""
+        output_path = tmp_path / "debug.mp4"
+
+        with DebugVideoWriter(output_path, width=1920, height=1080, fps=30.0) as writer:
+            frame = Frame(
+                raw=np.zeros((1920, 1080, 3), dtype=np.uint8),
+                frame_no=1,
+                filter_keep=True,
+            )
+
+            result = writer.handle(frame)
+
+            assert result is frame
+
+        assert output_path.exists()
+
+    def test_writer_handles_exception_in_exit(self, tmp_path: Path) -> None:
+        """Test that writer closes even if exception occurs."""
+        output_path = tmp_path / "debug.mp4"
+
+        writer = DebugVideoWriter(output_path, width=100, height=100, fps=30.0)
+        writer.__enter__()
+
+        exception_raised = False
+        try:
+            raise ValueError("Test exception")  # noqa: TRY301
+        except ValueError:
+            exception_raised = True
+        finally:
+            writer.__exit__(None, None, None)
+
+        assert exception_raised
+        assert writer._closed is True
+
+
+class TestDebugVideoIntegration:
+    """Integration tests for debug video in motion detection pipeline."""
+
+    def test_overlay_and_writer_used_together(self, tmp_path: Path) -> None:
+        """Test that overlay and writer can be used together at full resolution."""
+        mock_watcher = Mock(spec=Watcher)
+        mock_watcher.state = WatcherStateEnum.GREEN
+        mock_motion = Mock(spec=MogMotion)
+        mock_motion.motion_mask = None
+
+        overlay = DebugVideoOverlay(
+            watcher=mock_watcher,
+            motion_handler=mock_motion,
+        )
+
+        output_path = tmp_path / "debug.mp4"
+        writer = DebugVideoWriter(output_path, width=1920, height=1080, fps=30.0)
+        writer.__enter__()
+
+        try:
+            frame = Frame(
+                raw=np.zeros((1920, 1080, 3), dtype=np.uint8),
+                frame_no=1,
+                motion_proportion=0.5,
+                timestamp=1.0,
+                filter_keep=True,
+            )
+            frame.rescale = np.zeros((160, 120, 3), dtype=np.uint8)
+
+            frame = overlay.handle(frame)
+            writer.handle(frame)
+        finally:
+            writer.__exit__(None, None, None)
+
+        assert output_path.exists()

--- a/tests/lib/test_frame.py
+++ b/tests/lib/test_frame.py
@@ -406,7 +406,13 @@ class TestFrameTiling:
     def test_get_tile_returns_none_for_invalid_coordinates(self):
         raw = np.zeros((100, 200, 3), dtype=np.uint8)
         frame = Frame(
-            raw=raw, frame_no=1, tiles=[raw], tiling_cols=1, tiling_rows=1, tiling_width=200, tiling_height=100
+            raw=raw,
+            frame_no=1,
+            tiles=[raw],
+            tiling_cols=1,
+            tiling_rows=1,
+            tiling_width=200,
+            tiling_height=100,
         )
 
         assert frame.get_tile(-1, 0) is None
@@ -422,7 +428,13 @@ class TestFrameTiling:
         tiles = [tile1, tile2]
 
         frame = Frame(
-            raw=raw, frame_no=1, tiles=tiles, tiling_cols=2, tiling_rows=1, tiling_width=100, tiling_height=50
+            raw=raw,
+            frame_no=1,
+            tiles=tiles,
+            tiling_cols=2,
+            tiling_rows=1,
+            tiling_width=100,
+            tiling_height=50,
         )
 
         assert np.array_equal(frame.get_tile(0, 0), tile1)

--- a/tests/lib/test_segment_frame_tracking.py
+++ b/tests/lib/test_segment_frame_tracking.py
@@ -212,6 +212,7 @@ def test_output_clip_metadata_model() -> None:
         transition_metrics=WatcherTransitionMetrics(),
         transition_window_metrics={},
         config=config,
+        source_fps=30.0,
     )
 
     # Test with timestamps (stream)

--- a/tests/lib/test_segment_metadata.py
+++ b/tests/lib/test_segment_metadata.py
@@ -141,7 +141,6 @@ class TestFindSegmentsForFramerange:
 
     def test_find_segments_for_framerange_basic(self, setup_segments_dir: Path) -> None:
         """Test finding segments for a frame range."""
-
         # Range 100-200 overlaps with segment 1 (0-150) and segment 2 (151-300)
         result = find_segments_for_framerange(100, 200, setup_segments_dir)
         assert result is not None
@@ -151,28 +150,24 @@ class TestFindSegmentsForFramerange:
 
     def test_find_segments_spans_multiple_files(self, setup_segments_dir: Path) -> None:
         """Test finding segments that span multiple files."""
-
         result = find_segments_for_framerange(100, 350, setup_segments_dir)
         assert result is not None
         assert len(result) == 3
 
     def test_find_segments_no_overlap(self, setup_segments_dir: Path) -> None:
         """Test finding segments with no overlap."""
-
         result = find_segments_for_framerange(500, 600, setup_segments_dir)
         assert result is not None
         assert len(result) == 0
 
     def test_find_segments_incomplete_range(self, setup_segments_dir: Path) -> None:
         """Test finding segments when range extends beyond available segments."""
-
         # Request range that extends beyond last segment
         result = find_segments_for_framerange(400, 500, setup_segments_dir)
         assert result is None  # Should wait for more segments
 
     def test_find_segments_no_metadata_files(self, tmp_path: Path) -> None:
         """Test finding segments when no metadata files exist."""
-
         segments_dir = tmp_path / "segments"
         segments_dir.mkdir()
 
@@ -181,7 +176,6 @@ class TestFindSegmentsForFramerange:
 
     def test_find_segments_missing_segment_file(self, tmp_path: Path) -> None:
         """Test finding segments when segment file is missing."""
-
         segments_dir = tmp_path / "segments"
         segments_dir.mkdir()
 
@@ -200,7 +194,6 @@ class TestFindSegmentsForFramerange:
 
     def test_find_segments_exact_boundary(self, setup_segments_dir: Path) -> None:
         """Test finding segments at exact boundaries."""
-
         # Exact start of first segment
         result = find_segments_for_framerange(0, 50, setup_segments_dir)
         assert result is not None
@@ -213,7 +206,6 @@ class TestFindSegmentsForFramerange:
 
     def test_find_segments_single_frame(self, setup_segments_dir: Path) -> None:
         """Test finding segment for a single frame."""
-
         result = find_segments_for_framerange(200, 200, setup_segments_dir)
         assert result is not None
         assert len(result) == 1

--- a/tests/lib/test_states.py
+++ b/tests/lib/test_states.py
@@ -48,7 +48,6 @@ def test_states(video_path: str) -> None:
 
 def test_create_motion_process_restart_on_exit_auto_detect_file(video_path: Path) -> None:
     """Test that file paths auto-detect as restart_on_exit=False."""
-
     msg_queue: Queue = Queue()
     config = WatchConfig(rtsp_stream=str(video_path))
 
@@ -66,7 +65,6 @@ def test_create_motion_process_restart_on_exit_auto_detect_file(video_path: Path
 
 def test_create_motion_process_restart_on_exit_auto_detect_rtsp() -> None:
     """Test that RTSP URLs auto-detect as restart_on_exit=True."""
-
     msg_queue: Queue = Queue()
     config = WatchConfig(rtsp_stream="rtsp://localhost:8554/stream")
 
@@ -84,7 +82,6 @@ def test_create_motion_process_restart_on_exit_auto_detect_rtsp() -> None:
 
 def test_create_motion_process_restart_on_exit_explicit_override() -> None:
     """Test explicit restart_on_exit override."""
-
     msg_queue: Queue = Queue()
     config = WatchConfig(rtsp_stream="samples/synth/synth_0.0100_1.000.mp4")
 
@@ -107,7 +104,6 @@ def test_motion_window_tracks_amber_to_green() -> None:
     This is a regression test for the bug where windows were only tracked during
     RED state, causing fragmentation when the state machine oscillated rapidly.
     """
-
     watcher = Watcher(
         motion=MogMotion(history=10, threshold=16, detect_shadows=False, kernel_size=0.005),
         transition_metrics=WatcherTransitionMetrics(

--- a/tests/lib/test_stats.py
+++ b/tests/lib/test_stats.py
@@ -13,7 +13,8 @@ def test_get_video_stats(video_path: Path) -> None:
     assert stats.y == 2160
     assert stats.colourspace == Colourspace.RGB
     assert stats.fps == 30
-    assert stats.frame_count == 150
+    # Frame count may vary slightly due to rounding in duration-based calculation
+    assert 150 <= stats.frame_count <= 151
     assert stats.shape == (2160, 3840, 3)
     assert stats.nbytes == 2160 * 3840 * 3
     assert stats.frame_duration == int(1000 / 30)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -220,7 +220,10 @@ def test_get_pipeline_runs_by_video(db_engine, sample_video_stats, sample_rich_r
 
 
 def test_classification_result_unique_constraint(
-    db_engine, sample_video_stats, sample_rich_result, sample_pipeline_config
+    db_engine,
+    sample_video_stats,
+    sample_rich_result,
+    sample_pipeline_config,
 ):
     """Test that the unique constraint on ClassificationResult works correctly."""
     outcome = PipelineOutcome(
@@ -303,7 +306,10 @@ def test_video_recorded_at_persisted(db_engine, sample_video_stats, sample_rich_
 
 
 def test_video_recorded_at_does_not_overwrite_existing(
-    db_engine, sample_video_stats, sample_rich_result, sample_pipeline_config
+    db_engine,
+    sample_video_stats,
+    sample_rich_result,
+    sample_pipeline_config,
 ) -> None:
     """A second import must not clobber a previously-set recorded_at."""
     outcome = PipelineOutcome(
@@ -329,7 +335,10 @@ def test_video_recorded_at_does_not_overwrite_existing(
 
 
 def test_video_recorded_at_default_none(
-    db_engine, sample_video_stats, sample_rich_result, sample_pipeline_config
+    db_engine,
+    sample_video_stats,
+    sample_rich_result,
+    sample_pipeline_config,
 ) -> None:
     """Without a recorded_at argument the column should remain None."""
     outcome = PipelineOutcome(

--- a/tests/test_web_db.py
+++ b/tests/test_web_db.py
@@ -379,7 +379,7 @@ def test_list_runs_for_video_eager_loads_batches(db_engine, sample_pipeline_conf
                 species_name="Red Fox",
                 confidence=ConfidenceLevel.HIGH,
             ),
-        )
+        ),
     ]
     stats = VideoStats(fps=30.0, frame_count=10, x=1280, y=720, colourspace=Colourspace.RGB)
     outcome = PipelineOutcome(


### PR DESCRIPTION
## Summary

This PR implements a significant improvement to the video concatenation process, moving from a simple stream-copy approach to a more robust FFmpeg-based workflow that supports frame-accurate trimming. It also introduces a new debug video feature to visualize motion detection state and overlays in real-time.

## Changes

### 🎥 Video Concatenation & Trimming
- **Replaced PyAV with FFmpeg**: The `concat_videos` function now uses the FFmpeg CLI for concatenation, providing better control over the output.
- **Frame-Accurate Trimming**: Added support for `trim_start_frame` and `trim_end_frame` during concatenation.
- **Dynamic Frame Mapping**: Implemented `_build_segment_infos` and updated `WatcherManager` to calculate the exact frame positions within a concatenated sequence, ensuring that clips are trimmed precisely to the detected motion window.
- **Improved Metadata Handling**: Now uses `ffprobe` to retrieve actual frame counts and durations from segments to avoid drift during trimming.

### 🛠️ Debugging & Observability
- **New Debug Video Feature**: Introduced `src/wildcamtools/lib/debug_video.py` and a corresponding CLI option `--debug-video` in the `watch` command.
- **Motion Visualization**: The debug output overlays the current state machine color (e.g., GREEN, AMBER, RED) and motion contours directly onto the video frames.
- **Integration**: Updated `WatcherManager` to pass the debug video path through to the underlying motion processes.

### 🧹 Code Quality & Refactoring
- **CLI Improvements**: Improved input validation and formatting across `ai.py`, `db.py`, and `watch.py`.
- **AI Pipeline Cleanup**: Standardized docstrings and added missing return type documentation in `batch_processing.py`, `pipeline.py`, and `parallel_processing.py`.
- **Logic Simplification**: Refactored label comparison logic in `label_comparison.py` to remove redundant `else` blocks.

## Testing

- **Verification of Trimming**: Verified that the `concat_videos` function correctly handles `source_fps` and calculates concatenated frame ranges.
- **Debug Output**: Verified that the `watch` command now accepts the `--debug-video` flag and validates the output directory.
- **FFmpeg Dependency**: The system now explicitly relies on `ffmpeg` and `ffprobe` being available in the system path for concatenation and metadata retrieval.